### PR TITLE
ReadName tokenization and post tokenization compression pipeline for ReadNames

### DIFF
--- a/codec_map.json
+++ b/codec_map.json
@@ -7,7 +7,7 @@
   "NextRefID": "Brotli",
   "NextPos": "Brotli",
   "TemplateLength": "Brotli",
-  "ReadName": "Zstd",
+  "ReadName": "Brotli",
   "RawCigar": "Brotli",
   "RawSequence": "Brotli",
   "RawQual": "Zstd",

--- a/gbam_tools/Cargo.toml
+++ b/gbam_tools/Cargo.toml
@@ -30,6 +30,8 @@ brotli = "3.3.4"
 zstd = "0.12"
 once_cell = "1.19"
 xz2 = "0.1.7"
+chrono = "0.4"
+sha2 = "0.10"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/gbam_tools/src/compressor.rs
+++ b/gbam_tools/src/compressor.rs
@@ -192,7 +192,6 @@ impl Compressor {
         let mut tokenizer = IlluminaTokenizer::new();
         match tokenizer.tokenize_batch(&read_name_refs) {
             Ok(tokenized) => {
-                println!("Tokenization successful! Applying post-tokenization compression...");
                 
                 // Apply post-tokenization compression
                 let post_compressor = PostTokenizationCompressor::new(

--- a/gbam_tools/src/compressor.rs
+++ b/gbam_tools/src/compressor.rs
@@ -1,4 +1,5 @@
 use super::Codecs;
+use super::meta::{FileMeta, TokenizationMethod};
 use crate::writer::BlockInfo;
 use crate::SIZE_LIMIT;
 use flume::{Receiver, Sender};
@@ -10,6 +11,7 @@ use brotli::CompressorWriter;
 use zstd::stream::encode_all;
 // use lz4::EncoderBuilder;
 use std::io::Write;
+use std::mem;
 
 use std::sync::{Mutex, OnceLock};
 use std::fmt::Write as FmtWrite; // For formatting into String
@@ -20,7 +22,11 @@ use std::fs::File;
 use lzzzz::lz4;
 use xz2::write::XzEncoder;
 
-use crate::tokenizer_encoding::{IlluminaTokenizer, ReadNameAnalyzer, ReadNamePattern, ByteUtils, PostTokenizationCompressor, PostTokenizationConfig};
+use crate::tokenizer_encoding::{
+    IlluminaTokenizer, ReadNameAnalyzer, ReadNamePattern,
+    ByteUtils, PostTokenizationCompressor, PostTokenizationConfig, TokenizedReadName
+};
+use chrono::Local;
 
 
 pub(crate) enum OrderingKey {
@@ -33,6 +39,20 @@ pub(crate) struct CompressTask {
     pub ordering_key: OrderingKey,
     pub block_info: BlockInfo,
     pub buf: Vec<u8>,
+    pub dictionary_info: Option<DictionaryInfo>, 
+}
+
+#[derive(Debug)]
+pub struct DictionaryInfo {
+    pub action: DictionaryAction,
+    pub tokenization_method: TokenizationMethod,
+}
+
+#[derive(Debug)]
+pub enum DictionaryAction {
+    CreateNew(Vec<u8>), // Serialized dictionary data
+    UseExisting(u32),   // Dictionary ID
+    None,               // No tokenization
 }
 pub(crate) struct Compressor {
     compr_pool: ThreadPool,
@@ -58,6 +78,7 @@ impl Compressor {
                     ordering_key: OrderingKey::UnusedBlock,
                     block_info: BlockInfo::default(),
                     buf: vec![0; SIZE_LIMIT],
+                    dictionary_info: None,
                 })
                 .unwrap();
         }
@@ -75,13 +96,200 @@ impl Compressor {
         }
     }
 
+    fn prepare_readname_dictionary(
+        &self, 
+        data: &[u8], 
+        uncompr_size: usize,
+        file_meta: &FileMeta
+    ) -> Option<DictionaryInfo> {
+        // Extract read names
+        let read_name_refs = self.extract_read_names(data, uncompr_size);
+        
+        if read_name_refs.is_empty() || !ReadNameAnalyzer::should_tokenize(&read_name_refs) {
+            return None;
+        }
+        
+        // Check for existing compatible dictionary
+        // if let Some(existing_id) = file_meta.find_compatible_dictionary() {
+        //     return Some(DictionaryInfo {
+        //         action: DictionaryAction::UseExisting(existing_id),
+        //         tokenization_method: TokenizationMethod::IlluminaModern, // Or detect from dict
+        //     });
+        // }
+        
+        // Need to create new dictionary
+        let mut tokenizer = IlluminaTokenizer::new();
+        if let Ok(tokenized) = tokenizer.tokenize_batch(&read_name_refs) {
+            let dict_data = tokenizer.serialize_dictionary();
+            let method = Self::determine_tokenization_method(&tokenized);
+            
+            Some(DictionaryInfo {
+                action: DictionaryAction::CreateNew(dict_data),
+                tokenization_method: method,
+            })
+        } else {
+            None
+        }
+    }
+    
+    fn extract_read_names<'a>(&self, data: &'a [u8], uncompr_size: usize) -> Vec<&'a [u8]> {
+        let mut read_name_refs = Vec::new();
+        let mut offset = 0;
+        
+        while offset < uncompr_size {
+            if let Some(null_pos) = data[offset..uncompr_size].iter().position(|&b| b == 0) {
+                let read_name = &data[offset..offset + null_pos];
+                if !read_name.is_empty() {
+                    read_name_refs.push(read_name);
+                }
+                offset += null_pos + 1;
+            } else {
+                if offset < uncompr_size {
+                    read_name_refs.push(&data[offset..uncompr_size]);
+                }
+                break;
+            }
+        }
+        
+        read_name_refs
+    }
+    
+    fn determine_tokenization_method(tokenized: &[TokenizedReadName]) -> TokenizationMethod {
+        if tokenized.is_empty() {
+            TokenizationMethod::None
+        } else if tokenized[0].flowcell_id == 0 {
+            TokenizationMethod::IlluminaLegacy
+        } else {
+            TokenizationMethod::IlluminaModern
+        }
+    }
+
+    fn compress_readname_block(data: &[u8], buf: &mut Vec<u8>, block_info: &BlockInfo) -> Vec<u8> {
+        // Extract read names
+        let mut read_name_refs = Vec::new();
+        let mut offset = 0;
+        
+        while offset < block_info.uncompr_size {
+            if let Some(null_pos) = data[offset..block_info.uncompr_size].iter().position(|&b| b == 0) {
+                let read_name = &data[offset..offset + null_pos];
+                if !read_name.is_empty() {
+                    read_name_refs.push(read_name);
+                }
+                offset += null_pos + 1;
+            } else {
+                if offset < block_info.uncompr_size {
+                    read_name_refs.push(&data[offset..block_info.uncompr_size]);
+                }
+                break;
+            }
+        }
+        
+        if read_name_refs.is_empty() {
+            return compress(&data[..block_info.uncompr_size], mem::take(buf), block_info.codec)
+        }
+        
+        // Tokenize read names
+        let mut tokenizer = IlluminaTokenizer::new();
+        match tokenizer.tokenize_batch(&read_name_refs) {
+            Ok(tokenized) => {
+                println!("Tokenization successful! Applying post-tokenization compression...");
+                
+                // Apply post-tokenization compression
+                let post_compressor = PostTokenizationCompressor::new(
+                    PostTokenizationConfig::default()
+                );
+                
+                match post_compressor.compress_tokenized_data(&tokenized, tokenizer.get_dictionary()) {
+                    Ok(compressed_data) => {
+                        let original_total_size: usize = read_name_refs.iter().map(|name| name.len()).sum();
+                        
+                        compressed_data
+                    }
+                    Err(e) => {
+                        eprintln!("Post-tokenization compression failed: {}, falling back to basic tokenization", e);
+                        Self::fallback_tokenization(&tokenized, buf, block_info.codec)
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Tokenization failed: {}, using standard compression", e);
+                return compress(&data[..block_info.uncompr_size], mem::take(buf), block_info.codec)
+            }
+        }
+    }
+    
+    fn fallback_tokenization(tokenized: &[TokenizedReadName], buf: &mut Vec<u8>, codec: Codecs) -> Vec<u8> {
+        let mut encoded_data = Vec::new();
+        
+        // Store only tokens (dictionary is in FileMeta)
+        encoded_data.extend_from_slice(&(tokenized.len() as u32).to_le_bytes());
+        
+        for token in tokenized {
+            encoded_data.push(token.instrument_id);
+            encoded_data.extend_from_slice(&token.run_id.to_le_bytes());
+            encoded_data.push(token.flowcell_id);
+            encoded_data.push(token.lane);
+            encoded_data.extend_from_slice(&token.tile.to_le_bytes());
+            encoded_data.extend_from_slice(&token.x_coord.to_le_bytes());
+            encoded_data.extend_from_slice(&token.y_coord.to_le_bytes());
+            
+            if let Some(umi_id) = token.umi_id {
+                encoded_data.extend_from_slice(&umi_id.to_le_bytes());
+            } else {
+                encoded_data.extend_from_slice(&0xFFFFu16.to_le_bytes());
+            }
+            
+            encoded_data.push(token.read_num);
+            encoded_data.push(token.flags);
+            
+            if let Some(index_id) = token.index_id {
+                encoded_data.push(index_id);
+            } else {
+                encoded_data.push(0xFF);
+            }
+        }
+        
+        compress(&encoded_data, std::mem::take(buf), codec)
+    }
+    
     pub fn compress_block(
         &mut self,
         ordering_key: OrderingKey,
-        block_info: BlockInfo,
+        mut block_info: BlockInfo,
         data: Vec<u8>,
         codec: Codecs,
+        file_meta: &FileMeta,
     ) {
+        let dictionary_info = if block_info.field == Fields::ReadName {
+            self.prepare_readname_dictionary(&data, block_info.uncompr_size, file_meta)
+        } else {
+            None
+        };
+        
+        // Set block info based on dictionary decision
+        match &dictionary_info {
+            Some(dict_info) => {
+                match &dict_info.action {
+                    DictionaryAction::UseExisting(dict_id) => {
+                        block_info.dictionary_id = Some(*dict_id);
+                        block_info.is_tokenized = true;
+                    }
+                    DictionaryAction::CreateNew(_) => {
+                        block_info.dictionary_id = Some(0); // Placeholder, will be updated
+                        block_info.is_tokenized = true;
+                    }
+                    DictionaryAction::None => {
+                        block_info.dictionary_id = None;
+                        block_info.is_tokenized = false;
+                    }
+                }
+            }
+            None => {
+                block_info.dictionary_id = None;
+                block_info.is_tokenized = false;
+            }
+        }
+
         let buf_queue_tx = self.buf_tx.clone();
         let buf_queue_rx = self.buf_rx.clone();
         let compressed_tx = self.compr_data_tx.clone();
@@ -91,135 +299,27 @@ impl Compressor {
                 let mut buf = buf_queue_rx.recv().unwrap();
                 buf.clear();
                 
-                let compr_data = if block_info.field == Fields::ReadName {
-                    // Extract read names from the block for tokenization testing
-                    let mut read_name_refs = Vec::new();
-                    let mut offset = 0;
-                    
-                    // Parse read names from the block (assuming null-terminated strings)
-                    while offset < block_info.uncompr_size {
-                        if let Some(null_pos) = data[offset..block_info.uncompr_size].iter().position(|&b| b == 0) {
-                            let read_name = &data[offset..offset + null_pos];
-                            if !read_name.is_empty() {
-                                read_name_refs.push(read_name);
-                            }
-                            offset += null_pos + 1;
-                        } else {
-                            if offset < block_info.uncompr_size {
-                                read_name_refs.push(&data[offset..block_info.uncompr_size]);
-                            }
-                            break;
-                        }
-                    }
-                
-                    // Test tokenization if we have read names
-                    if !read_name_refs.is_empty() {
-                        if ReadNameAnalyzer::should_tokenize(&read_name_refs) {
-                            println!("Tokenizing read names...");
-                            
-                            let mut tokenizer = IlluminaTokenizer::new();
-                            match tokenizer.tokenize_batch(&read_name_refs) {
-                                Ok(tokenized) => {
-                                    println!("Tokenization successful! Applying post-tokenization compression...");
-                                    
-                                    // Apply post-tokenization compression pipeline
-                                    let post_compressor = PostTokenizationCompressor::new(
-                                        PostTokenizationConfig::default()
-                                    );
-                                    
-                                    match post_compressor.compress_tokenized_data(&tokenized, tokenizer.get_dictionary()) {
-                                        Ok(compressed_data) => {
-                                            let original_total_size: usize = read_name_refs.iter().map(|name| name.len()).sum();
-                                            
-                                            println!("\n=== Post-Tokenization Compression Results ===");
-                                            println!("Original block size: {} bytes", block_info.uncompr_size);
-                                            println!("Original read names total: {} bytes", original_total_size);
-                                            println!("Post-tokenization compressed size: {} bytes", compressed_data.len());
-                                            println!("Final compression ratio: {:.2}x", original_total_size as f64 / compressed_data.len() as f64);
-                                            println!("Space saved: {:.1}%", 
-                                                     (1.0 - compressed_data.len() as f64 / original_total_size as f64) * 100.0);
-                                            
-                                            compressed_data
-                                        }
-                                        Err(e) => {
-                                            eprintln!("Post-tokenization compression failed: {}, falling back", e);
-                                            
-                                            // Fallback to simple tokenization + basic compression
-                                            let mut encoded_data = Vec::new();
-                                            
-                                            // Serialize dictionary
-                                            let serialized_dict = tokenizer.serialize_dictionary();
-                                            encoded_data.extend_from_slice(&(serialized_dict.len() as u32).to_le_bytes());
-                                            encoded_data.extend_from_slice(&serialized_dict);
-                                            
-                                            // Serialize tokenized data
-                                            encoded_data.extend_from_slice(&(tokenized.len() as u32).to_le_bytes());
-                                            for token in &tokenized {
-                                                encoded_data.push(token.instrument_id);
-                                                encoded_data.extend_from_slice(&token.run_id.to_le_bytes());
-                                                encoded_data.push(token.flowcell_id);
-                                                encoded_data.push(token.lane);
-                                                encoded_data.extend_from_slice(&token.tile.to_le_bytes());
-                                                encoded_data.extend_from_slice(&token.x_coord.to_le_bytes());
-                                                encoded_data.extend_from_slice(&token.y_coord.to_le_bytes());
-                                                
-                                                if let Some(umi_id) = token.umi_id {
-                                                    encoded_data.extend_from_slice(&umi_id.to_le_bytes());
-                                                } else {
-                                                    encoded_data.extend_from_slice(&0xFFFFu16.to_le_bytes());
-                                                }
-                                                
-                                                encoded_data.push(token.read_num);
-                                                encoded_data.push(token.flags);
-                                                
-                                                if let Some(index_id) = token.index_id {
-                                                    encoded_data.push(index_id);
-                                                } else {
-                                                    encoded_data.push(0xFF);
-                                                }
-                                            }
-                                            
-                                            // Apply basic compression
-                                            compress(&encoded_data, buf, block_info.codec)
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("Tokenization failed: {}, falling back to original compression", e);
-                                    compress(&data[..block_info.uncompr_size], buf, block_info.codec)
-                                }
-                            }
-                        } else {
-                            println!("Tokenization not beneficial for this dataset");
-                            compress(&data[..block_info.uncompr_size], buf, block_info.codec)
-                        }
-                    } else {
-                        compress(&data[..block_info.uncompr_size], buf, block_info.codec)
-                    }
+                let compr_data = if block_info.field == Fields::ReadName && block_info.is_tokenized {
+                    // Perform tokenization and compression
+                    Self::compress_readname_block(&data, &mut buf, &block_info)
                 } else {
-                    // Non-read-name fields, compress normally
-                    compress(&data[..block_info.uncompr_size], buf, block_info.codec)
+                    // Standard compression
+                    compress(&data[..block_info.uncompr_size], std::mem::take(&mut buf), block_info.codec)
                 };
                 
-                buf_queue_tx.send(data).unwrap();
-    
-                let field_name = format!("{:?}", block_info.field);
-                let uncompressed_size = block_info.uncompr_size;
-                let compressed_size = compr_data.len();
-    
-                let log_line = format!(
-                    "Field: {}, Uncompressed: {}, Compressed: {}\n",
-                    field_name, uncompressed_size, compressed_size
-                );
-    
+                // Send the compression result
                 compressed_tx
                     .send(CompressTask {
                         ordering_key,
                         block_info,
                         buf: compr_data,
+                        dictionary_info,
                     })
                     .unwrap();
-            });
+                
+                // **IMPORTANT**: Return the buffer to the pool for reuse
+                buf_queue_tx.send(buf).unwrap();
+            })
         });
     }
 

--- a/gbam_tools/src/lib.rs
+++ b/gbam_tools/src/lib.rs
@@ -45,6 +45,7 @@ pub mod meta;
 mod stats;
 /// GBAM writer
 pub mod writer;
+pub mod tokenizer_encoding;
 
 // use self::writer::Writer;
 // pub use {ParsingTemplate, Reader};

--- a/gbam_tools/src/meta.rs
+++ b/gbam_tools/src/meta.rs
@@ -188,12 +188,6 @@ impl FileMeta {
         // let dict_id = self.read_name_dictionaries.len() as u32;
         let dict_id = Local::now().timestamp_millis() as u32;
         self.next_dictionary_id += 1;
-        println!("Adding dictionary with ID: {}", dict_id);
-
-        match String::from_utf8(dict_data.clone()) {
-            Ok(s) => println!("Human-readable dictionary data:\n{}", s),
-            Err(_) => println!("Dictionary data (not valid UTF-8): {:?}", dict_data),
-        }
         
         self.read_name_dictionaries.insert(dict_id, SerializedDictionary {
             dictionary_data: dict_data,

--- a/gbam_tools/src/meta.rs
+++ b/gbam_tools/src/meta.rs
@@ -9,6 +9,8 @@ use serde::de::{MapAccess, Visitor};
 // use serde::de::{Deserialize, Deserializer};
 // use serde_json::Result;
 use std::collections::HashMap;
+use sha2::{Sha256, Digest};
+use chrono::Local;
 
 /// Holds data related to GBAM file: gbam version, seekpos to meta.
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
@@ -19,6 +21,8 @@ pub(crate) struct FileInfo {
     pub crc32: u32,
     pub is_sorted: bool,
     pub creation_command: String,
+    #[serde(default)]
+    pub read_name_dictionaries: HashMap<u32, SerializedDictionary>,
 }
 
 impl FileInfo {
@@ -36,8 +40,25 @@ impl FileInfo {
             crc32,
             creation_command: full_command,
             is_sorted,
+            read_name_dictionaries: HashMap::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedDictionary {
+    pub dictionary_data: Vec<u8>,
+    pub block_count: usize, // How many blocks use this dictionary
+    pub method: TokenizationMethod,
+    pub created_at_block: u32, // Which block first created this dictionary
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TokenizationMethod {
+    None,
+    IlluminaLegacy,
+    IlluminaModern,
+    PostTokenizationCompressed,
 }
 
 /// Should be enough for JSON.
@@ -103,6 +124,11 @@ pub struct BlockMeta {
     pub block_size: u32,
     pub uncompressed_size: u64,
     pub stats: Option<Stat>,
+    #[serde(default)]
+    pub dictionary_id: Option<u32>,
+    
+    #[serde(default)]
+    pub is_tokenized: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -143,6 +169,9 @@ pub struct FileMeta {
     field_to_meta: [FieldMeta; FIELDS_NUM],
     sam_header: Vec<u8>,
     name_to_ref_id: Vec<(String, u32)>,
+    #[serde(default)]
+    pub read_name_dictionaries: HashMap<u32, SerializedDictionary>,
+    pub next_dictionary_id: u32,
 }
 
 impl FileMeta {
@@ -153,6 +182,47 @@ impl FileMeta {
     #[allow(dead_code)]
     pub fn get_sam_header(&self) -> &[u8] {
         &self.sam_header[..]
+    }
+
+    pub fn add_dictionary(&mut self, dict_data: Vec<u8>, method: TokenizationMethod, block_num: u32) -> u32 {
+        // let dict_id = self.read_name_dictionaries.len() as u32;
+        let dict_id = Local::now().timestamp_millis() as u32;
+        self.next_dictionary_id += 1;
+        println!("Adding dictionary with ID: {}", dict_id);
+
+        match String::from_utf8(dict_data.clone()) {
+            Ok(s) => println!("Human-readable dictionary data:\n{}", s),
+            Err(_) => println!("Dictionary data (not valid UTF-8): {:?}", dict_data),
+        }
+        
+        self.read_name_dictionaries.insert(dict_id, SerializedDictionary {
+            dictionary_data: dict_data,
+            block_count: 1,
+            method,
+            created_at_block: block_num,
+        });
+        
+        dict_id
+    }
+
+    pub fn increment_dictionary_usage(&mut self, dict_id: u32) {
+        if let Some(dict) = self.read_name_dictionaries.get_mut(&dict_id) {
+            dict.block_count += 1;
+        }
+    }
+    
+    pub fn get_dictionary(&self, dict_id: u32) -> Option<&SerializedDictionary> {
+        self.read_name_dictionaries.get(&dict_id)
+    }
+    
+    pub fn get_dictionaries(&self) -> &HashMap<u32, SerializedDictionary> {
+        &self.read_name_dictionaries
+    }
+    
+    pub fn find_compatible_dictionary(&self) -> Option<u32> {
+        // Simple implementation - return first available dictionary
+        // Could be enhanced to check dictionary compatibility
+        self.read_name_dictionaries.keys().next().copied()
     }
 }
 
@@ -262,6 +332,8 @@ impl FileMeta {
             field_to_meta: map,
             sam_header,
             name_to_ref_id: ref_seqs,
+            read_name_dictionaries: HashMap::new(),
+            next_dictionary_id: 0,
         }
     }
 

--- a/gbam_tools/src/reader/column.rs
+++ b/gbam_tools/src/reader/column.rs
@@ -172,7 +172,6 @@ fn fetch_block(inner_column: &mut Inner, block_num: usize) -> Result<()> {
     if uncompressed_size > 0 {
         // Check if this is a tokenized ReadName block
         if field == &Fields::ReadName && block_meta.is_tokenized {
-            println!("Processing tokenized ReadName block {}", block_num);
             
             match decode_tokenized_readname_block(
                 data, 
@@ -182,9 +181,7 @@ fn fetch_block(inner_column: &mut Inner, block_num: usize) -> Result<()> {
                 codec,
                 block_num
             ) {
-                Ok(_) => {
-                    println!("Successfully processed tokenized block {}", block_num);
-                }
+                Ok(_) => {}
                 Err(e) => {
                     eprintln!("Tokenized decoding failed for block {}: {}", block_num, e);
                     eprintln!("This likely indicates a metadata inconsistency - block marked as tokenized but contains standard data");
@@ -473,7 +470,6 @@ fn decode_post_tokenization_compressed_readnames(
     _codec: &Codecs,
     block_id: usize
 ) -> std::io::Result<()> {
-    println!("Starting post-tokenization compressed decoding, data size: {}", compressed_data.len());
     
     use crate::tokenizer_encoding::post_compression::{PostTokenizationCompressor, PostTokenizationConfig};
     
@@ -482,7 +478,6 @@ fn decode_post_tokenization_compressed_readnames(
     
     let tokens = match post_compressor.decompress_tokenized_data(compressed_data, dictionary) {
         Ok(tokens) => {
-            println!("Post-tokenization decompression successful, {} tokens", tokens.len());
             tokens
         }
         Err(e) => {
@@ -494,7 +489,6 @@ fn decode_post_tokenization_compressed_readnames(
     // Convert tokens back to read names and write to buffer
     match convert_tokens_to_buffer(&tokens, dictionary, dest_buffer) {
         Ok(_) => {
-            println!("Successfully converted {} post-tokenized tokens to buffer", tokens.len());
             Ok(())
         }
         Err(e) => {
@@ -514,17 +508,12 @@ pub fn decode_tokenized_readname_block(
 ) -> std::io::Result<()> {
     
     if let Some(dict_id) = block_meta.dictionary_id {
-        println!("Decoding tokenized ReadName block with dictionary ID: {}", dict_id);
         
         let dict_entry = file_meta.get_dictionary(dict_id).unwrap();
         let dictionary = deserialize_dictionary(&dict_entry.dictionary_data).unwrap();
         
-        println!("Dictionary loaded, method: {:?}", dict_entry.method);
-        
         // Based on compression logs, ALL blocks use post-tokenization compression
         // The compression never fell back to fallback_tokenization
-        println!("Using post-tokenization decompression (only method used during compression)");
-        
         decode_post_tokenization_compressed_readnames(
             compressed_data, 
             dest_buffer, 

--- a/gbam_tools/src/reader/column.rs
+++ b/gbam_tools/src/reader/column.rs
@@ -13,6 +13,9 @@ use std::io::{Read, Write};
 use xz2::read::XzDecoder;
 
 use crate::{meta::FileMeta, Codecs};
+use crate::tokenizer_encoding::{IlluminaTokenizer, TokenizedReadName};
+use crate::tokenizer_encoding::dictionary::ReadNameDictionary;
+use crate::meta::{TokenizationMethod, SerializedDictionary};
 
 // Contains fields needed both for fixed sized fields and variable sized fields.
 pub struct Inner {
@@ -154,7 +157,6 @@ impl VariableColumn {
 
 /// Fetch and decompress a data block.
 fn fetch_block(inner_column: &mut Inner, block_num: usize) -> Result<()> {
-    // println!("Fetching for {}", inner_column.field);
     let field = &inner_column.field;
     let block_meta = inner_column.meta.view_blocks(field).get(block_num).unwrap();
     let reader = &inner_column.reader;
@@ -163,15 +165,423 @@ fn fetch_block(inner_column: &mut Inner, block_num: usize) -> Result<()> {
 
     let data = &reader[usize::try_from(block_meta.seekpos).unwrap()
         ..usize::try_from(block_meta.seekpos + block_size as u64).unwrap()];
-    // inner_column.buffer.clear();
-    // dbg!(uncompressed_size);
+    
     inner_column.buffer.resize(uncompressed_size as usize, 0);
     let codec = inner_column.meta.get_field_codec(field);
 
     if uncompressed_size > 0 {
-        decompress_block(data, &mut inner_column.buffer, codec).expect("Decompression failed.");
+        // Check if this is a tokenized ReadName block
+        if field == &Fields::ReadName && block_meta.is_tokenized {
+            println!("Processing tokenized ReadName block {}", block_num);
+            
+            match decode_tokenized_readname_block(
+                data, 
+                &mut inner_column.buffer, 
+                block_meta, 
+                &inner_column.meta, 
+                codec,
+                block_num
+            ) {
+                Ok(_) => {
+                    println!("Successfully processed tokenized block {}", block_num);
+                }
+                Err(e) => {
+                    eprintln!("Tokenized decoding failed for block {}: {}", block_num, e);
+                    eprintln!("This likely indicates a metadata inconsistency - block marked as tokenized but contains standard data");
+                    return Err(e);
+                }
+            }
+        } else {
+            // Standard decompression
+            decompress_block(data, &mut inner_column.buffer, codec)
+                .expect("Decompression failed.");
+        }
     }
 
+    Ok(())
+}
+
+pub fn deserialize_dictionary(data: &[u8]) -> std::result::Result<ReadNameDictionary, Box<dyn std::error::Error>> {
+    let mut cursor = std::io::Cursor::new(data);
+    let mut dictionary = ReadNameDictionary::new();
+    
+    // Read instruments
+    let instruments_count = cursor.read_u32::<LittleEndian>()? as usize;
+    for _ in 0..instruments_count {
+        let len = cursor.read_u32::<LittleEndian>()? as usize;
+        let mut instrument = vec![0u8; len];
+        cursor.read_exact(&mut instrument)?;
+        dictionary.add_instrument(&instrument); // Add & to pass slice
+    }
+    
+    // Read flowcells
+    let flowcells_count = cursor.read_u32::<LittleEndian>()? as usize;
+    for _ in 0..flowcells_count {
+        let len = cursor.read_u32::<LittleEndian>()? as usize;
+        let mut flowcell = vec![0u8; len];
+        cursor.read_exact(&mut flowcell)?;
+        dictionary.add_flowcell(&flowcell); // Add & to pass slice
+    }
+    
+    // Read UMIs
+    let umis_count = cursor.read_u32::<LittleEndian>()? as usize;
+    for _ in 0..umis_count {
+        let len = cursor.read_u32::<LittleEndian>()? as usize;
+        let mut umi = vec![0u8; len];
+        cursor.read_exact(&mut umi)?;
+        dictionary.add_umi(&umi); // Add & to pass slice
+    }
+    
+    // Read indices
+    let indices_count = cursor.read_u32::<LittleEndian>()? as usize;
+    for _ in 0..indices_count {
+        let len = cursor.read_u32::<LittleEndian>()? as usize;
+        let mut index = vec![0u8; len];
+        cursor.read_exact(&mut index)?;
+        dictionary.add_index(&index); // Add & to pass slice
+    }
+    
+    Ok(dictionary)
+}
+
+pub fn detokenize(
+    token: &TokenizedReadName, 
+    dictionary: &ReadNameDictionary
+) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>> {
+    // Get instrument name
+    let instrument = dictionary.get_instrument(token.instrument_id)
+        .ok_or("Invalid instrument ID")?;
+
+    // LEGACY FORMAT: flowcell_id == 0
+    if token.flowcell_id == 0 {
+        let mut read_name = format!(
+            "{}:{}:{}:{}:{}",
+            String::from_utf8_lossy(instrument),
+            token.lane,
+            token.tile,
+            token.x_coord,
+            token.y_coord
+        );
+
+        // Add index if present
+        if let Some(index_id) = token.index_id {
+            if let Some(index) = dictionary.get_index(index_id) {
+                read_name.push_str(&format!("#{}", String::from_utf8_lossy(index)));
+            }
+        }
+
+        // Add UMI if present
+        if let Some(umi_id) = token.umi_id {
+            if let Some(umi) = dictionary.get_umi(umi_id) {
+                read_name.push_str(&format!("|{}", String::from_utf8_lossy(umi)));
+            }
+        }
+
+        Ok(read_name.into_bytes())
+    } else {
+        // MODERN FORMAT (unchanged)
+        let flowcell = dictionary.get_flowcell(token.flowcell_id - 1)
+            .ok_or("Invalid flowcell ID")?;
+        let mut read_name = format!(
+            "{}:{}:{}:{}:{}:{}:{}",
+            String::from_utf8_lossy(instrument),
+            token.run_id,
+            String::from_utf8_lossy(flowcell),
+            token.lane,
+            token.tile,
+            token.x_coord,
+            token.y_coord
+        );
+
+        // Add UMI if present
+        if let Some(umi_id) = token.umi_id {
+            if let Some(umi) = dictionary.get_umi(umi_id) {
+                read_name.push_str(&format!(":{}", String::from_utf8_lossy(umi)));
+            }
+        }
+
+        // Add read number
+        read_name.push_str(&format!(" {}", token.read_num));
+
+        // Add flags
+        if token.flags > 0 {
+            read_name.push_str(&format!(" {}", token.flags));
+        }
+
+        // Add index if present
+        if let Some(index_id) = token.index_id {
+            if let Some(index) = dictionary.get_index(index_id) {
+                read_name.push_str(&format!(" {}", String::from_utf8_lossy(index)));
+            }
+        }
+
+        Ok(read_name.into_bytes())
+    }
+}
+
+pub fn parse_tokens(data: &[u8]) -> std::result::Result<Vec<TokenizedReadName>, Box<dyn std::error::Error>> {
+    let mut cursor = std::io::Cursor::new(data);
+    
+    // Read token count
+    let token_count = cursor.read_u32::<LittleEndian>()? as usize;
+    let mut tokens = Vec::with_capacity(token_count);
+    
+    for _ in 0..token_count {
+        let instrument_id = cursor.read_u8()?;
+        let run_id = cursor.read_u32::<LittleEndian>()?;
+        let flowcell_id = cursor.read_u8()?;
+        let lane = cursor.read_u8()?;
+        let tile = cursor.read_u16::<LittleEndian>()?;
+        let x_coord = cursor.read_u32::<LittleEndian>()?;
+        let y_coord = cursor.read_u32::<LittleEndian>()?;
+        
+        let umi_raw = cursor.read_u16::<LittleEndian>()?;
+        let umi_id = if umi_raw == 0xFFFF { None } else { Some(umi_raw) };
+        
+        let read_num = cursor.read_u8()?;
+        let flags = cursor.read_u8()?;
+        
+        let index_raw = cursor.read_u8()?;
+        let index_id = if index_raw == 0xFF { None } else { Some(index_raw) };
+        
+        tokens.push(TokenizedReadName {
+            instrument_id,
+            run_id,
+            flowcell_id,
+            lane,
+            tile,
+            x_coord,
+            y_coord,
+            umi_id,
+            read_num,
+            flags,
+            index_id,
+        });
+    }
+    
+    Ok(tokens)
+}
+
+fn convert_tokens_to_buffer(
+    tokens: &[TokenizedReadName],
+    dictionary: &ReadNameDictionary,
+    dest_buffer: &mut Vec<u8>
+) -> std::io::Result<()> {
+    dest_buffer.clear();
+    
+    for token in tokens {
+        let read_name = detokenize(token, dictionary)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        
+        // Write read name as null-terminated string (matching original BAM format)
+        dest_buffer.extend_from_slice(&read_name);
+        dest_buffer.push(0); // Null terminator
+    }
+    
+    Ok(())
+}
+
+fn decode_standard_tokenized_readnames(
+    compressed_data: &[u8],
+    dest_buffer: &mut Vec<u8>,
+    dictionary: &ReadNameDictionary,
+    codec: &Codecs,
+) -> std::io::Result<()> {
+    println!("Starting standard tokenized decoding (fallback format), compressed data size: {}", compressed_data.len());
+    
+    // First decompress using standard codec (this should work now)
+    let mut decompressed_data = Vec::new();
+    match decompress_block(compressed_data, &mut decompressed_data, codec) {
+        Ok(_) => println!("Standard decompression successful, decompressed size: {}", decompressed_data.len()),
+        Err(e) => {
+            eprintln!("Standard decompression failed: {}", e);
+            return Err(e);
+        }
+    }
+    
+    // Parse tokens from the decompressed data using fallback format
+    let tokens = match parse_fallback_tokens(&decompressed_data) {
+        Ok(tokens) => {
+            println!("Successfully parsed {} tokens from fallback format", tokens.len());
+            tokens
+        }
+        Err(e) => {
+            eprintln!("Fallback token parsing failed: {}", e);
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()));
+        }
+    };
+    
+    // Convert tokens back to read names and write to buffer
+    convert_tokens_to_buffer(&tokens, dictionary, dest_buffer)
+}
+
+// New function to parse the exact format used by fallback_tokenization
+pub fn parse_fallback_tokens(data: &[u8]) -> std::result::Result<Vec<TokenizedReadName>, Box<dyn std::error::Error>> {
+    let mut cursor = std::io::Cursor::new(data);
+    
+    // Read token count
+    let token_count = cursor.read_u32::<LittleEndian>()? as usize;
+    println!("Parsing {} tokens from fallback format", token_count);
+    let mut tokens = Vec::with_capacity(token_count);
+    
+    for i in 0..token_count {
+        // Parse exactly as written by fallback_tokenization
+        let instrument_id = cursor.read_u8()?;
+        let run_id = cursor.read_u32::<LittleEndian>()?;
+        let flowcell_id = cursor.read_u8()?;
+        let lane = cursor.read_u8()?;
+        let tile = cursor.read_u16::<LittleEndian>()?;
+        let x_coord = cursor.read_u32::<LittleEndian>()?;
+        let y_coord = cursor.read_u32::<LittleEndian>()?;
+        
+        let umi_raw = cursor.read_u16::<LittleEndian>()?;
+        let umi_id = if umi_raw == 0xFFFF { None } else { Some(umi_raw) };
+        
+        let read_num = cursor.read_u8()?;
+        let flags = cursor.read_u8()?;
+        
+        let index_raw = cursor.read_u8()?;
+        let index_id = if index_raw == 0xFF { None } else { Some(index_raw) };
+        
+        tokens.push(TokenizedReadName {
+            instrument_id,
+            run_id,
+            flowcell_id,
+            lane,
+            tile,
+            x_coord,
+            y_coord,
+            umi_id,
+            read_num,
+            flags,
+            index_id,
+        });
+        
+        if i < 5 {
+            println!("Token {}: instrument={}, run={}, flowcell={}, lane={}, tile={}, x={}, y={}", 
+                i, instrument_id, run_id, flowcell_id, lane, tile, x_coord, y_coord);
+        }
+    }
+    
+    Ok(tokens)
+}
+
+fn decode_post_tokenization_compressed_readnames(
+    compressed_data: &[u8],
+    dest_buffer: &mut Vec<u8>,
+    dictionary: &ReadNameDictionary,
+    _codec: &Codecs,
+    block_id: usize
+) -> std::io::Result<()> {
+    println!("Starting post-tokenization compressed decoding, data size: {}", compressed_data.len());
+    
+    use crate::tokenizer_encoding::post_compression::{PostTokenizationCompressor, PostTokenizationConfig};
+    
+    // Decompress using PostTokenizationCompressor
+    let post_compressor = PostTokenizationCompressor::new(PostTokenizationConfig::default());
+    
+    let tokens = match post_compressor.decompress_tokenized_data(compressed_data, dictionary) {
+        Ok(tokens) => {
+            println!("Post-tokenization decompression successful, {} tokens", tokens.len());
+            tokens
+        }
+        Err(e) => {
+            eprintln!("Post-tokenization decompression failed: {}", e);
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()));
+        }
+    };
+    
+    // Convert tokens back to read names and write to buffer
+    match convert_tokens_to_buffer(&tokens, dictionary, dest_buffer) {
+        Ok(_) => {
+            println!("Successfully converted {} post-tokenized tokens to buffer", tokens.len());
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Post-tokenized token to buffer conversion failed: {}", e);
+            Err(e)
+        }
+    }
+}
+
+pub fn decode_tokenized_readname_block(
+    compressed_data: &[u8],
+    dest_buffer: &mut Vec<u8>,
+    block_meta: &crate::meta::BlockMeta,
+    file_meta: &FileMeta,
+    codec: &Codecs,
+    block_id: usize
+) -> std::io::Result<()> {
+    
+    if let Some(dict_id) = block_meta.dictionary_id {
+        println!("Decoding tokenized ReadName block with dictionary ID: {}", dict_id);
+        
+        let dict_entry = file_meta.get_dictionary(dict_id).unwrap();
+        let dictionary = deserialize_dictionary(&dict_entry.dictionary_data).unwrap();
+        
+        println!("Dictionary loaded, method: {:?}", dict_entry.method);
+        
+        // Based on compression logs, ALL blocks use post-tokenization compression
+        // The compression never fell back to fallback_tokenization
+        println!("Using post-tokenization decompression (only method used during compression)");
+        
+        decode_post_tokenization_compressed_readnames(
+            compressed_data, 
+            dest_buffer, 
+            &dictionary,
+            codec,
+            block_id
+        )
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Block marked as tokenized but no dictionary ID found"
+        ))
+    }
+}
+
+fn decode_fallback_tokenized_readnames(
+    compressed_data: &[u8],
+    dest_buffer: &mut Vec<u8>,
+    dictionary: &ReadNameDictionary,
+    codec: &Codecs,
+) -> std::io::Result<()> {
+    println!("Decoding fallback tokenized format, size: {} bytes", compressed_data.len());
+    println!("Using codec: {:?}", codec);
+    
+    // Step 1: Decompress using standard codec (Brotli)
+    let mut decompressed_data = Vec::new();
+    println!("Attempting decompression with {:?}...", codec);
+    
+    match decompress_block(compressed_data, &mut decompressed_data, codec) {
+        Ok(_) => {
+            println!("Decompression successful: {} bytes", decompressed_data.len());
+            
+            // Debug the decompressed data
+            if decompressed_data.len() >= 8 {
+                println!("First 16 bytes of decompressed data: {:02x?}", &decompressed_data[..std::cmp::min(16, decompressed_data.len())]);
+                
+                let token_count = u32::from_le_bytes([
+                    decompressed_data[0], decompressed_data[1], decompressed_data[2], decompressed_data[3]
+                ]);
+                println!("Token count from decompressed data: {}", token_count);
+            }
+        }
+        Err(e) => {
+            println!("Decompression failed: {}", e);
+            return Err(e);
+        }
+    }
+    
+    // Step 2: Parse tokens from binary format
+    let tokens = parse_fallback_tokens(&decompressed_data)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    println!("Parsed {} tokens", tokens.len());
+    
+    // Step 3: Convert tokens back to ReadName strings
+    convert_tokens_to_buffer(&tokens, dictionary, dest_buffer)?;
+    println!("Converted to {} ReadName bytes", dest_buffer.len());
+    
     Ok(())
 }
 

--- a/gbam_tools/src/tokenizer_encoding/analyzer.rs
+++ b/gbam_tools/src/tokenizer_encoding/analyzer.rs
@@ -1,0 +1,146 @@
+//! Pattern analysis for read names
+
+use super::utils::ByteUtils;
+
+#[derive(Debug, PartialEq)]
+pub enum ReadNamePattern {
+    Illumina,
+    PacBio,
+    Custom,
+    Unstructured,
+}
+
+pub struct ReadNameAnalyzer;
+
+impl ReadNameAnalyzer {
+    pub fn detect_pattern(read_names: &[&[u8]]) -> ReadNamePattern {
+        if read_names.is_empty() {
+            return ReadNamePattern::Unstructured;
+        }
+
+        let illumina_count = read_names.iter()
+            .filter(|name| Self::is_illumina_pattern(name))
+            .count();
+
+        let pacbio_count = read_names.iter()
+            .filter(|name| Self::is_pacbio_pattern(name))
+            .count();
+
+        let total = read_names.len();
+        
+        if illumina_count as f64 / total as f64 > 0.8 {
+            ReadNamePattern::Illumina
+        } else if pacbio_count as f64 / total as f64 > 0.8 {
+            ReadNamePattern::PacBio
+        } else if Self::has_custom_pattern(read_names) {
+            ReadNamePattern::Custom
+        } else {
+            ReadNamePattern::Unstructured
+        }
+    }
+
+    fn is_illumina_pattern(name: &[u8]) -> bool {
+        // Pattern: instrument:run:flowcell:lane:tile:x:y:UMI:readnum:filtered:control:index
+        ByteUtils::count_byte(name, b':') >= 6 && 
+        ByteUtils::split_bytes(name, b':').len() >= 7
+    }
+
+    fn is_pacbio_pattern(name: &[u8]) -> bool {
+        // Pattern: movieName/holeNumber/start_end
+        name.contains(&b'/') && 
+        ByteUtils::count_byte(name, b'/') == 2
+    }
+
+    fn has_custom_pattern(read_names: &[&[u8]]) -> bool {
+        // Check for common prefixes or structures
+        if read_names.len() < 2 {
+            return false;
+        }
+
+        let first = read_names[0];
+        let common_prefix_len = read_names.iter()
+            .map(|name| ByteUtils::common_prefix_length(first, name))
+            .min()
+            .unwrap_or(0);
+
+        common_prefix_len > first.len() / 3
+    }
+
+    pub fn should_tokenize(read_names: &[&[u8]]) -> bool {
+        if read_names.len() < 10 {
+            return false; // Not worth tokenizing small datasets
+        }
+
+        let pattern = Self::detect_pattern(read_names);
+        match pattern {
+            ReadNamePattern::Illumina | ReadNamePattern::PacBio => true,
+            ReadNamePattern::Custom => {
+                // Check redundancy level
+                ByteUtils::calculate_redundancy(read_names) > 0.3
+            },
+            ReadNamePattern::Unstructured => false,
+        }
+    }
+
+    pub fn analyze_efficiency(read_names: &[&[u8]]) -> f64 {
+        if read_names.is_empty() {
+            return 0.0;
+        }
+
+        let pattern = Self::detect_pattern(read_names);
+        let redundancy = ByteUtils::calculate_redundancy(read_names);
+        
+        match pattern {
+            ReadNamePattern::Illumina => 0.8 + redundancy * 0.2,
+            ReadNamePattern::PacBio => 0.6 + redundancy * 0.4,
+            ReadNamePattern::Custom => redundancy,
+            ReadNamePattern::Unstructured => redundancy * 0.1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_illumina_detection() {
+        let illumina_names: Vec<Vec<u8>> = vec![
+            b"HWI-ST1234:123:H0ABCADXX:1:1101:1234:5678:ACGTACGT:1:N:0:ATCACG".to_vec(),
+            b"HWI-ST1234:123:H0ABCADXX:1:1101:1234:5679:ACGTACGT:2:N:0:ATCACG".to_vec(),
+        ];
+
+        let name_refs: Vec<&[u8]> = illumina_names.iter().map(|v| v.as_slice()).collect();
+        let pattern = ReadNameAnalyzer::detect_pattern(&name_refs);
+        assert_eq!(pattern, ReadNamePattern::Illumina);
+    }
+
+    #[test]
+    fn test_pacbio_detection() {
+        let pacbio_names: Vec<Vec<u8>> = vec![
+            b"movie1/12345/0_1000".to_vec(),
+            b"movie1/12346/100_1100".to_vec(),
+        ];
+
+        let name_refs: Vec<&[u8]> = pacbio_names.iter().map(|v| v.as_slice()).collect();
+        let pattern = ReadNameAnalyzer::detect_pattern(&name_refs);
+        assert_eq!(pattern, ReadNamePattern::PacBio);
+    }
+
+    #[test]
+    fn test_should_tokenize() {
+        // Too few reads
+        let few_names: Vec<Vec<u8>> = vec![
+            b"HWI-ST1234:123:H0ABCADXX:1:1101:1234:5678".to_vec(),
+        ];
+        let few_refs: Vec<&[u8]> = few_names.iter().map(|v| v.as_slice()).collect();
+        assert!(!ReadNameAnalyzer::should_tokenize(&few_refs));
+
+        // Enough Illumina reads
+        let many_names: Vec<Vec<u8>> = (0..20)
+            .map(|i| format!("HWI-ST1234:123:H0ABCADXX:1:1101:{}:5678:ACGTACGT:1:N:0:ATCACG", 1000 + i).into_bytes())
+            .collect();
+        let many_refs: Vec<&[u8]> = many_names.iter().map(|v| v.as_slice()).collect();
+        assert!(ReadNameAnalyzer::should_tokenize(&many_refs));
+    }
+}

--- a/gbam_tools/src/tokenizer_encoding/dictionary.rs
+++ b/gbam_tools/src/tokenizer_encoding/dictionary.rs
@@ -1,0 +1,180 @@
+//! Dictionary management for read name components
+
+use std::collections::HashMap;
+
+/// Tokenized representation of a read name
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokenizedReadName {
+    pub instrument_id: u8,
+    pub run_id: u32,
+    pub flowcell_id: u8,
+    pub lane: u8,
+    pub tile: u16,
+    pub x_coord: u32,
+    pub y_coord: u32,
+    pub umi_id: Option<u16>,
+    pub read_num: u8,
+    pub flags: u8,
+    pub index_id: Option<u8>,
+}
+
+/// Dictionary for storing common read name components
+#[derive(Debug, Clone)]
+pub struct ReadNameDictionary {
+    pub instruments: Vec<Vec<u8>>,
+    pub flowcells: Vec<Vec<u8>>,
+    pub umis: Vec<Vec<u8>>,
+    pub indices: Vec<Vec<u8>>,
+    // Reverse lookup maps for encoding
+    instrument_map: HashMap<Vec<u8>, u8>,
+    flowcell_map: HashMap<Vec<u8>, u8>,
+    umi_map: HashMap<Vec<u8>, u16>,
+    index_map: HashMap<Vec<u8>, u8>,
+}
+
+impl ReadNameDictionary {
+    pub fn new() -> Self {
+        Self {
+            instruments: Vec::new(),
+            flowcells: Vec::new(),
+            umis: Vec::new(),
+            indices: Vec::new(),
+            instrument_map: HashMap::new(),
+            flowcell_map: HashMap::new(),
+            umi_map: HashMap::new(),
+            index_map: HashMap::new(),
+        }
+    }
+
+    pub fn add_instrument(&mut self, instrument: &[u8]) -> u8 {
+        let instrument_vec = instrument.to_vec();
+        if let Some(&id) = self.instrument_map.get(&instrument_vec) {
+            return id;
+        }
+        
+        if self.instruments.len() >= 255 {
+            // Return existing ID if we've hit the limit
+            return 254;
+        }
+        
+        let id = self.instruments.len() as u8;
+        self.instrument_map.insert(instrument_vec.clone(), id);
+        self.instruments.push(instrument_vec);
+        id
+    }
+
+    pub fn add_flowcell(&mut self, flowcell: &[u8]) -> u8 {
+        let flowcell_vec = flowcell.to_vec();
+        if let Some(&id) = self.flowcell_map.get(&flowcell_vec) {
+            return id;
+        }
+        
+        if self.flowcells.len() >= 255 {
+            return 254;
+        }
+        
+        let id = self.flowcells.len() as u8;
+        self.flowcell_map.insert(flowcell_vec.clone(), id);
+        self.flowcells.push(flowcell_vec);
+        id
+    }
+
+    pub fn add_umi(&mut self, umi: &[u8]) -> u16 {
+        let umi_vec = umi.to_vec();
+        if let Some(&id) = self.umi_map.get(&umi_vec) {
+            return id;
+        }
+        
+        if self.umis.len() >= 65535 {
+            return 65534;
+        }
+        
+        let id = self.umis.len() as u16;
+        self.umi_map.insert(umi_vec.clone(), id);
+        self.umis.push(umi_vec);
+        id
+    }
+
+    pub fn add_index(&mut self, index: &[u8]) -> u8 {
+        let index_vec = index.to_vec();
+        if let Some(&id) = self.index_map.get(&index_vec) {
+            return id;
+        }
+        
+        if self.indices.len() >= 255 {
+            return 254;
+        }
+        
+        let id = self.indices.len() as u8;
+        self.index_map.insert(index_vec.clone(), id);
+        self.indices.push(index_vec);
+        id
+    }
+
+    pub fn get_instrument(&self, id: u8) -> Option<&[u8]> {
+        self.instruments.get(id as usize).map(|v| v.as_slice())
+    }
+
+    pub fn get_flowcell(&self, id: u8) -> Option<&[u8]> {
+        self.flowcells.get(id as usize).map(|v| v.as_slice())
+    }
+
+    pub fn get_umi(&self, id: u16) -> Option<&[u8]> {
+        self.umis.get(id as usize).map(|v| v.as_slice())
+    }
+
+    pub fn get_index(&self, id: u8) -> Option<&[u8]> {
+        self.indices.get(id as usize).map(|v| v.as_slice())
+    }
+
+    pub fn total_size(&self) -> usize {
+        self.instruments.iter().map(|v| v.len()).sum::<usize>() +
+        self.flowcells.iter().map(|v| v.len()).sum::<usize>() +
+        self.umis.iter().map(|v| v.len()).sum::<usize>() +
+        self.indices.iter().map(|v| v.len()).sum::<usize>()
+    }
+
+    pub fn entry_counts(&self) -> (usize, usize, usize, usize) {
+        (
+            self.instruments.len(),
+            self.flowcells.len(),
+            self.umis.len(),
+            self.indices.len(),
+        )
+    }
+}
+
+impl Default for ReadNameDictionary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dictionary_operations() {
+        let mut dict = ReadNameDictionary::new();
+        
+        // Test adding and retrieving instruments
+        let id1 = dict.add_instrument(b"HWI-ST1234");
+        let id2 = dict.add_instrument(b"HWI-ST1234"); // Should return same ID
+        let id3 = dict.add_instrument(b"NextSeq");
+        
+        assert_eq!(id1, id2);
+        assert_ne!(id1, id3);
+        assert_eq!(dict.get_instrument(id1), Some(b"HWI-ST1234".as_slice()));
+        assert_eq!(dict.get_instrument(id3), Some(b"NextSeq".as_slice()));
+    }
+
+    #[test]
+    fn test_dictionary_size_calculation() {
+        let mut dict = ReadNameDictionary::new();
+        dict.add_instrument(b"HWI-ST1234");  // 10 bytes
+        dict.add_flowcell(b"H0ABCADXX");     // 8 bytes
+        
+        assert_eq!(dict.total_size(), 18);
+    }
+}

--- a/gbam_tools/src/tokenizer_encoding/dictionary.rs
+++ b/gbam_tools/src/tokenizer_encoding/dictionary.rs
@@ -1,6 +1,8 @@
 //! Dictionary management for read name components
 
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Write, BufWriter};
 
 /// Tokenized representation of a read name
 #[derive(Debug, Clone, PartialEq)]
@@ -44,6 +46,32 @@ impl ReadNameDictionary {
             umi_map: HashMap::new(),
             index_map: HashMap::new(),
         }
+    }
+
+    pub fn write_to_file(&self, path: &str) -> std::io::Result<()> {
+        let mut file = BufWriter::new(File::create(path)?);
+
+        writeln!(file, "Instruments:")?;
+        for (i, inst) in self.instruments.iter().enumerate() {
+            writeln!(file, "  [{}] {}", i, String::from_utf8_lossy(inst))?;
+        }
+
+        writeln!(file, "Flowcells:")?;
+        for (i, fc) in self.flowcells.iter().enumerate() {
+            writeln!(file, "  [{}] {}", i, String::from_utf8_lossy(fc))?;
+        }
+
+        writeln!(file, "UMIs:")?;
+        for (i, umi) in self.umis.iter().enumerate() {
+            writeln!(file, "  [{}] {}", i, String::from_utf8_lossy(umi))?;
+        }
+
+        writeln!(file, "Indices:")?;
+        for (i, idx) in self.indices.iter().enumerate() {
+            writeln!(file, "  [{}] {}", i, String::from_utf8_lossy(idx))?;
+        }
+
+        Ok(())
     }
 
     pub fn add_instrument(&mut self, instrument: &[u8]) -> u8 {

--- a/gbam_tools/src/tokenizer_encoding/encoder.rs
+++ b/gbam_tools/src/tokenizer_encoding/encoder.rs
@@ -1,0 +1,115 @@
+//! Coordinate delta encoding for read names
+
+#[derive(Debug, Clone)]
+pub struct CoordinateDeltas {
+    pub x_delta: i16,
+    pub y_delta: i16,
+    pub tile_delta: i16,
+}
+
+pub struct CoordinateEncoder {
+    last_x: u32,
+    last_y: u32,
+    last_tile: u16,
+}
+
+impl CoordinateEncoder {
+    pub fn new() -> Self {
+        Self {
+            last_x: 0,
+            last_y: 0,
+            last_tile: 0,
+        }
+    }
+
+    pub fn encode_coordinates(&mut self, x: u32, y: u32, tile: u16) -> CoordinateDeltas {
+        let deltas = CoordinateDeltas {
+            x_delta: (x as i32 - self.last_x as i32).clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+            y_delta: (y as i32 - self.last_y as i32).clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+            tile_delta: (tile as i32 - self.last_tile as i32).clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+        };
+
+        self.last_x = x;
+        self.last_y = y;
+        self.last_tile = tile;
+
+        deltas
+    }
+
+    pub fn decode_coordinates(&mut self, deltas: &CoordinateDeltas) -> (u32, u32, u16) {
+        self.last_x = (self.last_x as i32 + deltas.x_delta as i32).max(0) as u32;
+        self.last_y = (self.last_y as i32 + deltas.y_delta as i32).max(0) as u32;
+        self.last_tile = (self.last_tile as i32 + deltas.tile_delta as i32).max(0) as u16;
+
+        (self.last_x, self.last_y, self.last_tile)
+    }
+
+    pub fn reset(&mut self) {
+        self.last_x = 0;
+        self.last_y = 0;
+        self.last_tile = 0;
+    }
+
+    pub fn get_state(&self) -> (u32, u32, u16) {
+        (self.last_x, self.last_y, self.last_tile)
+    }
+}
+
+impl Default for CoordinateEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_coordinate_delta_encoding() {
+        let mut encoder = CoordinateEncoder::new();
+        
+        let coords = vec![
+            (1000, 2000, 1101),
+            (1001, 2000, 1101),
+            (1002, 2001, 1101),
+            (1000, 2010, 1102),
+        ];
+
+        let mut deltas = Vec::new();
+        for (x, y, tile) in coords.iter() {
+            deltas.push(encoder.encode_coordinates(*x, *y, *tile));
+        }
+
+        // Verify first delta is absolute values
+        assert_eq!(deltas[0].x_delta, 1000);
+        assert_eq!(deltas[0].y_delta, 2000);
+        assert_eq!(deltas[0].tile_delta, 1101);
+
+        // Verify subsequent deltas are differences
+        assert_eq!(deltas[1].x_delta, 1);   // 1001 - 1000
+        assert_eq!(deltas[1].y_delta, 0);   // 2000 - 2000
+        assert_eq!(deltas[1].tile_delta, 0); // 1101 - 1101
+
+        // Reset and decode
+        encoder.reset();
+        for (i, delta) in deltas.iter().enumerate() {
+            let (x, y, tile) = encoder.decode_coordinates(delta);
+            assert_eq!((x, y, tile), coords[i]);
+        }
+    }
+
+    #[test]
+    fn test_coordinate_overflow_protection() {
+        let mut encoder = CoordinateEncoder::new();
+        
+        // Test with values that would overflow i16
+        let large_coord = u32::MAX;
+        let deltas = encoder.encode_coordinates(large_coord, large_coord, u16::MAX);
+        
+        // Should be clamped to i16::MAX
+        assert_eq!(deltas.x_delta, i16::MAX);
+        assert_eq!(deltas.y_delta, i16::MAX);
+        assert_eq!(deltas.tile_delta, i16::MAX);
+    }
+}

--- a/gbam_tools/src/tokenizer_encoding/error.rs
+++ b/gbam_tools/src/tokenizer_encoding/error.rs
@@ -1,0 +1,24 @@
+//! Error types for read name tokenization
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum TokenizationError {
+    InvalidFormat(String),
+    ParseError(String),
+    InvalidDictionary(String),
+    UnsupportedPattern(String),
+}
+
+impl fmt::Display for TokenizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TokenizationError::InvalidFormat(msg) => write!(f, "Invalid format: {}", msg),
+            TokenizationError::ParseError(msg) => write!(f, "Parse error: {}", msg),
+            TokenizationError::InvalidDictionary(msg) => write!(f, "Dictionary error: {}", msg),
+            TokenizationError::UnsupportedPattern(msg) => write!(f, "Unsupported pattern: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for TokenizationError {}

--- a/gbam_tools/src/tokenizer_encoding/mod.rs
+++ b/gbam_tools/src/tokenizer_encoding/mod.rs
@@ -1,0 +1,30 @@
+//! Read Name Tokenization Library for CRAM-style compression
+//! 
+//! This library provides efficient tokenization of sequencing read names
+//! to achieve better compression ratios in bioinformatics file formats.
+
+pub mod error;
+pub mod utils;
+pub mod dictionary;
+pub mod tokenizer;
+pub mod analyzer;
+pub mod encoder;
+pub mod post_compression;
+
+// Re-export main types for convenience
+pub use error::TokenizationError;
+pub use dictionary::{ReadNameDictionary, TokenizedReadName};
+pub use tokenizer::IlluminaTokenizer;
+pub use analyzer::{ReadNameAnalyzer, ReadNamePattern};
+pub use encoder::{CoordinateEncoder, CoordinateDeltas};
+pub use utils::ByteUtils;
+pub use post_compression::{PostTokenizationCompressor, PostTokenizationConfig};
+
+/// Statistics about tokenization performance
+#[derive(Debug, Clone)]
+pub struct TokenizationStats {
+    pub total_reads: usize,
+    pub successfully_tokenized: usize,
+    pub dictionary_size: usize,
+    pub compression_ratio: f64,
+}

--- a/gbam_tools/src/tokenizer_encoding/post_compression.rs
+++ b/gbam_tools/src/tokenizer_encoding/post_compression.rs
@@ -1,0 +1,476 @@
+// src/tokenizer/post_compression.rs
+use crate::tokenizer_encoding::{TokenizedReadName, ReadNameDictionary, ByteUtils};
+use std::collections::HashMap;
+use flate2::{Compression, write::ZlibEncoder};
+use std::io::Write;
+
+#[derive(Debug, Clone)]
+pub struct PostTokenizationConfig {
+    pub use_rle: bool,
+    pub use_huffman: bool,
+    pub use_delta_encoding: bool,
+    pub use_deflate: bool,
+    pub rle_threshold: f64,
+}
+
+impl Default for PostTokenizationConfig {
+    fn default() -> Self {
+        Self {
+            use_rle: true,
+            use_huffman: true,
+            use_delta_encoding: true,
+            use_deflate: true,
+            rle_threshold: 0.2,
+        }
+    }
+}
+
+pub struct PostTokenizationCompressor {
+    config: PostTokenizationConfig,
+}
+
+impl PostTokenizationCompressor {
+    pub fn new(config: PostTokenizationConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn compress_tokenized_data(
+        &self,
+        tokenized: &[TokenizedReadName],
+        dictionary: &ReadNameDictionary,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        
+        // Step 1: Separate into streams
+        let streams = self.separate_into_streams(tokenized);
+        
+        // Step 2: Compress dictionary
+        let compressed_dict = self.compress_dictionary(dictionary)?;
+        
+        // Step 3: Compress each stream
+        let compressed_streams = self.compress_all_streams(&streams)?;
+        
+        // Step 4: Assemble final block
+        Ok(self.assemble_block(compressed_dict, compressed_streams))
+    }
+
+    fn separate_into_streams(&self, tokenized: &[TokenizedReadName]) -> TokenizedStreams {
+        let mut streams = TokenizedStreams::new(tokenized.len());
+        
+        for token in tokenized {
+            streams.instrument_ids.push(token.instrument_id);
+            streams.run_ids.push(token.run_id);
+            streams.flowcell_ids.push(token.flowcell_id);
+            streams.lanes.push(token.lane);
+            streams.tiles.push(token.tile);
+            streams.x_coords.push(token.x_coord);
+            streams.y_coords.push(token.y_coord);
+            streams.umi_ids.push(token.umi_id);
+            streams.read_nums.push(token.read_num);
+            streams.flags.push(token.flags);
+            streams.index_ids.push(token.index_id);
+        }
+        
+        streams
+    }
+
+    fn compress_categorical_stream(&self, data: &[u8], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut working_data = data.to_vec();
+        
+        // Stage 1: RLE if beneficial
+        if self.config.use_rle && self.calculate_rle_benefit(&working_data) > self.config.rle_threshold {
+            working_data = self.run_length_encode(&working_data);
+            println!("Applied RLE to {}: {} -> {} bytes", stream_name, data.len(), working_data.len());
+        }
+        
+        // Stage 2: Huffman encoding
+        if self.config.use_huffman && self.should_use_huffman(&working_data) {
+            working_data = self.huffman_encode(&working_data)?;
+            println!("Applied Huffman to {}: size after Huffman: {} bytes", stream_name, working_data.len());
+        }
+        
+        // Stage 3: Final DEFLATE compression
+        if self.config.use_deflate {
+            let deflated = self.deflate_compress(&working_data)?;
+            println!("Applied DEFLATE to {}: {} -> {} bytes", stream_name, working_data.len(), deflated.len());
+            working_data = deflated;
+        }
+        
+        Ok(working_data)
+    }
+
+    fn compress_numeric_stream(&self, data: &[u32], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // Stage 1: Delta encoding + varint
+        let mut compressed = if self.config.use_delta_encoding && data.len() > 1 {
+            println!("Applying delta encoding to {}", stream_name);
+            self.delta_encode_with_varint(data)
+        } else {
+            println!("Applying direct varint encoding to {}", stream_name);
+            self.direct_varint_encode(data)
+        };
+        
+        println!("{} after varint: {} bytes", stream_name, compressed.len());
+        
+        // Stage 2: Final compression
+        if self.config.use_deflate {
+            let deflated = self.deflate_compress(&compressed)?;
+            println!("{} after DEFLATE: {} -> {} bytes", stream_name, compressed.len(), deflated.len());
+            compressed = deflated;
+        }
+        
+        Ok(compressed)
+    }
+
+    fn compress_coordinate_streams(&self, x_coords: &[u32], y_coords: &[u32], tiles: &[u16]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        println!("Compressing coordinate streams...");
+        
+        // Stage 1: 2D delta encoding
+        let deltas = self.encode_2d_deltas(x_coords, y_coords, tiles);
+        println!("Coordinate deltas calculated: {} deltas", deltas.len());
+        
+        // Stage 2: Interleave and varint encode
+        let mut compressed = Vec::new();
+        for delta in &deltas {
+            compressed.extend(self.encode_varint(delta.dx));
+            compressed.extend(self.encode_varint(delta.dy));
+            compressed.extend(self.encode_varint(delta.dtile as i32));
+        }
+        
+        println!("Coordinates after varint: {} bytes", compressed.len());
+        
+        // Stage 3: Final compression
+        if self.config.use_deflate {
+            let deflated = self.deflate_compress(&compressed)?;
+            println!("Coordinates after DEFLATE: {} -> {} bytes", compressed.len(), deflated.len());
+            compressed = deflated;
+        }
+        
+        Ok(compressed)
+    }
+
+    fn compress_sparse_stream(&self, data: &[Option<u16>], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // Stage 1: Create bitmap and values
+        let mut bitmap = Vec::new();
+        let mut values = Vec::new();
+        let mut current_byte = 0u8;
+        let mut bit_pos = 0;
+        
+        for opt_val in data {
+            if let Some(val) = opt_val {
+                current_byte |= 1 << bit_pos;
+                values.extend(self.encode_varint(*val as i32));
+            }
+            
+            bit_pos += 1;
+            if bit_pos == 8 {
+                bitmap.push(current_byte);
+                current_byte = 0;
+                bit_pos = 0;
+            }
+        }
+        
+        // Push final byte if needed
+        if bit_pos > 0 {
+            bitmap.push(current_byte);
+        }
+        
+        println!("{}: bitmap {} bytes, values {} bytes", stream_name, bitmap.len(), values.len());
+        
+        // Stage 2: Compress bitmap and values
+        let compressed_bitmap = if self.config.use_deflate {
+            self.deflate_compress(&bitmap)?
+        } else {
+            bitmap
+        };
+        
+        let compressed_values = if self.config.use_deflate {
+            self.deflate_compress(&values)?
+        } else {
+            values
+        };
+        
+        // Stage 3: Combine
+        let mut result = Vec::new();
+        result.extend(self.encode_varint(compressed_bitmap.len() as i32));
+        result.extend(compressed_bitmap);
+        result.extend(self.encode_varint(compressed_values.len() as i32));
+        result.extend(compressed_values);
+        
+        println!("{} final size: {} bytes", stream_name, result.len());
+        Ok(result)
+    }
+
+    fn compress_sparse_u8_stream(&self, data: &[Option<u8>], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let u16_data: Vec<Option<u16>> = data.iter().map(|&opt| opt.map(|v| v as u16)).collect();
+        self.compress_sparse_stream(&u16_data, stream_name)
+    }
+
+    // Helper functions
+    fn calculate_rle_benefit(&self, data: &[u8]) -> f64 {
+        if data.len() < 10 {
+            return 0.0;
+        }
+        
+        let mut runs = 0usize;  // Explicitly specify type
+        let mut total_run_length = 0usize;  // Explicitly specify type
+        let mut current_run = 1usize;  // Explicitly specify type
+        
+        for i in 1..data.len() {
+            if data[i] == data[i-1] {
+                current_run += 1;
+            } else {
+                if current_run >= 3 {
+                    runs += 1;
+                    total_run_length += current_run;
+                }
+                current_run = 1;
+            }
+        }
+        
+        if current_run >= 3 {
+            runs += 1;
+            total_run_length += current_run;
+        }
+        
+        let bytes_saved = total_run_length.saturating_sub(runs * 2);
+        bytes_saved as f64 / data.len() as f64
+    }
+
+    fn run_length_encode(&self, data: &[u8]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        if data.is_empty() {
+            return encoded;
+        }
+        
+        let mut current = data[0];
+        let mut count = 1u32;
+        
+        for &byte in &data[1..] {
+            if byte == current && count < u32::MAX {
+                count += 1;
+            } else {
+                encoded.extend(self.encode_varint(count as i32));
+                encoded.push(current);
+                current = byte;
+                count = 1;
+            }
+        }
+        
+        encoded.extend(self.encode_varint(count as i32));
+        encoded.push(current);
+        encoded
+    }
+
+    fn should_use_huffman(&self, data: &[u8]) -> bool {
+        let mut frequencies = HashMap::new();
+        for &byte in data {
+            *frequencies.entry(byte).or_insert(0) += 1;
+        }
+        
+        let unique_symbols = frequencies.len();
+        unique_symbols < data.len() / 2 && unique_symbols > 1 && data.len() > 20
+    }
+
+    fn huffman_encode(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // Simplified: For now, just return the data
+        // A full implementation would build Huffman trees and encode
+        Ok(data.to_vec())
+    }
+
+    fn delta_encode_with_varint(&self, data: &[u32]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        encoded.extend(self.encode_varint(data[0] as i32));
+        
+        for i in 1..data.len() {
+            let delta = data[i] as i32 - data[i-1] as i32;
+            encoded.extend(self.encode_varint(delta));
+        }
+        
+        encoded
+    }
+
+    fn direct_varint_encode(&self, data: &[u32]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        for &value in data {
+            encoded.extend(self.encode_varint(value as i32));
+        }
+        encoded
+    }
+
+    fn encode_2d_deltas(&self, x_coords: &[u32], y_coords: &[u32], tiles: &[u16]) -> Vec<CoordinateDelta> {
+        let mut deltas = Vec::with_capacity(x_coords.len());
+        let mut last_x = 0u32;
+        let mut last_y = 0u32;
+        let mut last_tile = 0u16;
+        
+        for i in 0..x_coords.len() {
+            let delta = CoordinateDelta {
+                dx: x_coords[i] as i32 - last_x as i32,
+                dy: y_coords[i] as i32 - last_y as i32,
+                dtile: tiles[i] as i32 - last_tile as i32,
+            };
+            
+            deltas.push(delta);
+            last_x = x_coords[i];
+            last_y = y_coords[i];
+            last_tile = tiles[i];
+        }
+        
+        deltas
+    }
+
+    fn encode_varint(&self, mut value: i32) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        let mut uvalue = ((value << 1) ^ (value >> 31)) as u32; // ZigZag encoding
+        
+        while uvalue >= 0x80 {
+            encoded.push((uvalue & 0x7F) as u8 | 0x80);
+            uvalue >>= 7;
+        }
+        encoded.push(uvalue as u8);
+        encoded
+    }
+
+    fn deflate_compress(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data)?;
+        Ok(encoder.finish()?)
+    }
+
+    fn compress_all_streams(&self, streams: &TokenizedStreams) -> Result<CompressedStreams, Box<dyn std::error::Error>> {
+        println!("\n=== Compressing Individual Streams ===");
+        
+        Ok(CompressedStreams {
+            instrument_ids: self.compress_categorical_stream(&streams.instrument_ids, "instrument_ids")?,
+            run_ids: self.compress_numeric_stream(&streams.run_ids, "run_ids")?,
+            flowcell_ids: self.compress_categorical_stream(&streams.flowcell_ids, "flowcell_ids")?,
+            lanes: self.compress_categorical_stream(&streams.lanes, "lanes")?,
+            read_nums: self.compress_categorical_stream(&streams.read_nums, "read_nums")?,
+            flags: self.compress_categorical_stream(&streams.flags, "flags")?,
+            coordinates: self.compress_coordinate_streams(&streams.x_coords, &streams.y_coords, &streams.tiles)?,
+            umi_ids: self.compress_sparse_stream(&streams.umi_ids, "umi_ids")?,
+            index_ids: self.compress_sparse_u8_stream(&streams.index_ids, "index_ids")?,
+        })
+    }
+
+    fn compress_dictionary(&self, dictionary: &ReadNameDictionary) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut serialized = Vec::new();
+        
+        // Serialize each section
+        for (section_name, section) in [
+            ("instruments", &dictionary.instruments),
+            ("flowcells", &dictionary.flowcells), 
+            ("umis", &dictionary.umis),
+            ("indices", &dictionary.indices),
+        ] {
+            serialized.extend(self.encode_varint(section.len() as i32));
+            for item in section {
+                serialized.extend(self.encode_varint(item.len() as i32));
+                serialized.extend(item);
+            }
+        }
+        
+        println!("Dictionary serialized: {} bytes", serialized.len());
+        
+        if self.config.use_deflate {
+            let compressed = self.deflate_compress(&serialized)?;
+            println!("Dictionary after compression: {} -> {} bytes", serialized.len(), compressed.len());
+            Ok(compressed)
+        } else {
+            Ok(serialized)
+        }
+    }
+
+    fn assemble_block(&self, compressed_dict: Vec<u8>, compressed_streams: CompressedStreams) -> Vec<u8> {
+        let mut block = Vec::new();
+        
+        // Block header
+        block.extend(self.encode_varint(compressed_dict.len() as i32));
+        block.extend(compressed_dict);
+        
+        // Stream data
+        block.extend(self.encode_varint(compressed_streams.instrument_ids.len() as i32));
+        block.extend(compressed_streams.instrument_ids);
+        
+        block.extend(self.encode_varint(compressed_streams.run_ids.len() as i32));
+        block.extend(compressed_streams.run_ids);
+        
+        block.extend(self.encode_varint(compressed_streams.flowcell_ids.len() as i32));
+        block.extend(compressed_streams.flowcell_ids);
+        
+        block.extend(self.encode_varint(compressed_streams.lanes.len() as i32));
+        block.extend(compressed_streams.lanes);
+        
+        block.extend(self.encode_varint(compressed_streams.read_nums.len() as i32));
+        block.extend(compressed_streams.read_nums);
+        
+        block.extend(self.encode_varint(compressed_streams.flags.len() as i32));
+        block.extend(compressed_streams.flags);
+        
+        block.extend(self.encode_varint(compressed_streams.coordinates.len() as i32));
+        block.extend(compressed_streams.coordinates);
+        
+        block.extend(self.encode_varint(compressed_streams.umi_ids.len() as i32));
+        block.extend(compressed_streams.umi_ids);
+        
+        block.extend(self.encode_varint(compressed_streams.index_ids.len() as i32));
+        block.extend(compressed_streams.index_ids);
+        
+        println!("Final assembled block size: {} bytes", block.len());
+        block
+    }
+
+    // Add remaining helper methods...
+}
+
+#[derive(Debug)]
+struct TokenizedStreams {
+    instrument_ids: Vec<u8>,
+    run_ids: Vec<u32>,
+    flowcell_ids: Vec<u8>,
+    lanes: Vec<u8>,
+    tiles: Vec<u16>,
+    x_coords: Vec<u32>,
+    y_coords: Vec<u32>,
+    umi_ids: Vec<Option<u16>>,
+    read_nums: Vec<u8>,
+    flags: Vec<u8>,
+    index_ids: Vec<Option<u8>>,
+}
+
+impl TokenizedStreams {
+    fn new(capacity: usize) -> Self {
+        Self {
+            instrument_ids: Vec::with_capacity(capacity),
+            run_ids: Vec::with_capacity(capacity),
+            flowcell_ids: Vec::with_capacity(capacity),
+            lanes: Vec::with_capacity(capacity),
+            tiles: Vec::with_capacity(capacity),
+            x_coords: Vec::with_capacity(capacity),
+            y_coords: Vec::with_capacity(capacity),
+            umi_ids: Vec::with_capacity(capacity),
+            read_nums: Vec::with_capacity(capacity),
+            flags: Vec::with_capacity(capacity),
+            index_ids: Vec::with_capacity(capacity),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CoordinateDelta {
+    dx: i32,
+    dy: i32,
+    dtile: i32,
+}
+
+#[derive(Debug)]
+struct CompressedStreams {
+    instrument_ids: Vec<u8>,
+    run_ids: Vec<u8>,
+    flowcell_ids: Vec<u8>,
+    lanes: Vec<u8>,
+    read_nums: Vec<u8>,
+    flags: Vec<u8>,
+    coordinates: Vec<u8>,
+    umi_ids: Vec<u8>,
+    index_ids: Vec<u8>,
+}

--- a/gbam_tools/src/tokenizer_encoding/post_compression.rs
+++ b/gbam_tools/src/tokenizer_encoding/post_compression.rs
@@ -79,19 +79,16 @@ impl PostTokenizationCompressor {
         // Stage 1: RLE if beneficial
         if self.config.use_rle && self.calculate_rle_benefit(&working_data) > self.config.rle_threshold {
             working_data = self.run_length_encode(&working_data);
-            println!("Applied RLE to {}: {} -> {} bytes", stream_name, data.len(), working_data.len());
         }
         
         // Stage 2: Huffman encoding
         if self.config.use_huffman && self.should_use_huffman(&working_data) {
             working_data = self.huffman_encode(&working_data)?;
-            println!("Applied Huffman to {}: size after Huffman: {} bytes", stream_name, working_data.len());
         }
         
         // Stage 3: Final DEFLATE compression
         if self.config.use_deflate {
             let deflated = self.deflate_compress(&working_data)?;
-            println!("Applied DEFLATE to {}: {} -> {} bytes", stream_name, working_data.len(), deflated.len());
             working_data = deflated;
         }
         
@@ -101,19 +98,14 @@ impl PostTokenizationCompressor {
     fn compress_numeric_stream(&self, data: &[u32], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         // Stage 1: Delta encoding + varint
         let mut compressed = if self.config.use_delta_encoding && data.len() > 1 {
-            println!("Applying delta encoding to {}", stream_name);
             self.delta_encode_with_varint(data)
         } else {
-            println!("Applying direct varint encoding to {}", stream_name);
             self.direct_varint_encode(data)
         };
-        
-        println!("{} after varint: {} bytes", stream_name, compressed.len());
         
         // Stage 2: Final compression
         if self.config.use_deflate {
             let deflated = self.deflate_compress(&compressed)?;
-            println!("{} after DEFLATE: {} -> {} bytes", stream_name, compressed.len(), deflated.len());
             compressed = deflated;
         }
         
@@ -337,7 +329,6 @@ impl PostTokenizationCompressor {
     }
 
     fn compress_all_streams(&self, streams: &TokenizedStreams) -> Result<CompressedStreams, Box<dyn std::error::Error>> {
-        println!("\n=== Compressing Individual Streams ===");
         
         Ok(CompressedStreams {
             instrument_ids: self.compress_categorical_stream(&streams.instrument_ids, "instrument_ids")?,
@@ -419,6 +410,600 @@ impl PostTokenizationCompressor {
         block
     }
 
+    fn decode_varint(&self, data: &[u8], cursor: &mut usize) -> Result<i32, Box<dyn std::error::Error>> {
+        let mut result = 0u32;
+        let mut shift = 0;
+        
+        while *cursor < data.len() {
+            let byte = data[*cursor];
+            *cursor += 1;
+            
+            result |= ((byte & 0x7F) as u32) << shift;
+            
+            if (byte & 0x80) == 0 {
+                break;
+            }
+            
+            shift += 7;
+            if shift >= 35 { // Allow full 5-byte varint
+                return Err("Varint too long".into());
+            }
+        }
+        
+        // ZigZag decode: (n >> 1) ^ (-(n & 1))
+        let zigzag_decoded = ((result >> 1) as i32) ^ (-((result & 1) as i32));
+        Ok(zigzag_decoded)
+    }
+    
+    pub fn decompress_tokenized_data(
+        &self,
+        compressed_data: &[u8],
+        dictionary: &ReadNameDictionary,
+    ) -> Result<Vec<TokenizedReadName>, Box<dyn std::error::Error>> {
+        
+        println!("=== POST-TOKENIZATION DECOMPRESSION DEBUG ===");
+        println!("Compressed data size: {} bytes", compressed_data.len());
+        println!("First 16 bytes: {:02x?}", &compressed_data[..std::cmp::min(16, compressed_data.len())]);
+        
+        // Step 1: Parse the varint-encoded dictionary size
+        let mut cursor = 0;
+        let dict_size = self.decode_varint(compressed_data, &mut cursor)?;
+        println!("Dictionary size from varint: {} bytes (cursor at {})", dict_size, cursor);
+        
+        if dict_size < 0 || dict_size as usize > compressed_data.len() {
+            return Err(format!("Invalid dictionary size: {}", dict_size).into());
+        }
+        
+        // Step 2: Skip embedded dictionary (we use the provided one)
+        let embedded_dict = &compressed_data[cursor..cursor + dict_size as usize];
+        let streams_start = cursor + dict_size as usize;
+        
+        if streams_start > compressed_data.len() {
+            return Err("Invalid compressed data: dictionary size exceeds data length".into());
+        }
+        
+        println!("Embedded dictionary: {} bytes, streams start at: {}", dict_size, streams_start);
+        let streams_data = &compressed_data[streams_start..];
+        println!("Streams data size: {} bytes", streams_data.len());
+        
+        // Step 3: Decompress all streams
+        let streams = self.decompress_all_streams(streams_data)?;
+        
+        // Step 4: Reconstruct tokens from streams
+        Ok(self.reconstruct_tokens(streams))
+    }
+
+    fn decompress_all_streams(&self, streams_data: &[u8]) -> Result<TokenizedStreams, Box<dyn std::error::Error>> {
+        println!("\n=== Decompressing Individual Streams ===");
+        let mut cursor = 0;
+        
+        // Stream 1: instrument_ids
+        println!("Decompressing instrument_ids stream...");
+        let instrument_ids_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", instrument_ids_size);
+        if cursor + instrument_ids_size as usize > streams_data.len() {
+            return Err(format!("instrument_ids stream exceeds data bounds").into());
+        }
+        let instrument_ids_data = &streams_data[cursor..cursor + instrument_ids_size as usize];
+        cursor += instrument_ids_size as usize;
+        let instrument_ids = self.decompress_u8_stream(instrument_ids_data, "instrument_ids")?;
+        
+        // Stream 2: run_ids
+        println!("Decompressing run_ids stream...");
+        let run_ids_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", run_ids_size);
+        if cursor + run_ids_size as usize > streams_data.len() {
+            return Err(format!("run_ids stream exceeds data bounds").into());
+        }
+        let run_ids_data = &streams_data[cursor..cursor + run_ids_size as usize];
+        cursor += run_ids_size as usize;
+        let run_ids = self.decompress_u32_stream(run_ids_data, "run_ids")?;
+        
+        // Stream 3: flowcell_ids
+        println!("Decompressing flowcell_ids stream...");
+        let flowcell_ids_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", flowcell_ids_size);
+        if cursor + flowcell_ids_size as usize > streams_data.len() {
+            return Err(format!("flowcell_ids stream exceeds data bounds").into());
+        }
+        let flowcell_ids_data = &streams_data[cursor..cursor + flowcell_ids_size as usize];
+        cursor += flowcell_ids_size as usize;
+        let flowcell_ids = self.decompress_u8_stream(flowcell_ids_data, "flowcell_ids")?;
+        
+        // Stream 4: lanes
+        println!("Decompressing lanes stream...");
+        let lanes_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", lanes_size);
+        if cursor + lanes_size as usize > streams_data.len() {
+            return Err(format!("lanes stream exceeds data bounds").into());
+        }
+        let lanes_data = &streams_data[cursor..cursor + lanes_size as usize];
+        cursor += lanes_size as usize;
+        let lanes = self.decompress_u8_stream(lanes_data, "lanes")?;
+        
+        // Stream 5: read_nums
+        println!("Decompressing read_nums stream...");
+        let read_nums_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", read_nums_size);
+        if cursor + read_nums_size as usize > streams_data.len() {
+            return Err(format!("read_nums stream exceeds data bounds").into());
+        }
+        let read_nums_data = &streams_data[cursor..cursor + read_nums_size as usize];
+        cursor += read_nums_size as usize;
+        let read_nums = self.decompress_u8_stream(read_nums_data, "read_nums")?;
+        
+        // Stream 6: flags
+        println!("Decompressing flags stream...");
+        let flags_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", flags_size);
+        if cursor + flags_size as usize > streams_data.len() {
+            return Err(format!("flags stream exceeds data bounds").into());
+        }
+        let flags_data = &streams_data[cursor..cursor + flags_size as usize];
+        cursor += flags_size as usize;
+        let flags = self.decompress_u8_stream(flags_data, "flags")?;
+        
+        // Stream 7: coordinates (combined x_coords, y_coords, tiles)
+        println!("Decompressing coordinates stream...");
+        let coordinates_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", coordinates_size);
+        if cursor + coordinates_size as usize > streams_data.len() {
+            return Err(format!("coordinates stream exceeds data bounds").into());
+        }
+        let coordinates_data = &streams_data[cursor..cursor + coordinates_size as usize];
+        cursor += coordinates_size as usize;
+        let (x_coords, y_coords, tiles) = self.decompress_coordinate_streams(coordinates_data)?;
+        
+        // Stream 8: umi_ids (sparse)
+        println!("Decompressing umi_ids stream...");
+        let umi_ids_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", umi_ids_size);
+        if cursor + umi_ids_size as usize > streams_data.len() {
+            return Err(format!("umi_ids stream exceeds data bounds").into());
+        }
+        let umi_ids_data = &streams_data[cursor..cursor + umi_ids_size as usize];
+        cursor += umi_ids_size as usize;
+        let umi_ids = self.decompress_sparse_u16_stream(umi_ids_data, "umi_ids")?;
+        
+        // Stream 9: index_ids (sparse)
+        println!("Decompressing index_ids stream...");
+        let index_ids_size = self.decode_varint(streams_data, &mut cursor)?;
+        println!("  Size: {} bytes", index_ids_size);
+        if cursor + index_ids_size as usize > streams_data.len() {
+            return Err(format!("index_ids stream exceeds data bounds").into());
+        }
+        let index_ids_data = &streams_data[cursor..cursor + index_ids_size as usize];
+        cursor += index_ids_size as usize;
+        let index_ids = self.decompress_sparse_u8_stream(index_ids_data, "index_ids")?;
+        
+        println!("All streams decompressed successfully");
+        println!("Final cursor position: {} / {}", cursor, streams_data.len());
+        
+        Ok(TokenizedStreams {
+            instrument_ids,
+            run_ids,
+            flowcell_ids,
+            lanes,
+            tiles,
+            x_coords,
+            y_coords,
+            umi_ids,
+            read_nums,
+            flags,
+            index_ids,
+        })
+    }
+
+    fn deflate_decompress(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        use flate2::read::ZlibDecoder;
+        use std::io::Read;
+        
+        println!("      Attempting zlib decompression on {} bytes", data.len());
+        println!("      Data starts with: {:02x?}", &data[..std::cmp::min(8, data.len())]);
+        
+        let mut decoder = ZlibDecoder::new(data);
+        let mut decompressed = Vec::new();
+        match decoder.read_to_end(&mut decompressed) {
+            Ok(bytes_read) => {
+                println!("      ✓ Zlib decompression successful: {} bytes read", bytes_read);
+                Ok(decompressed)
+            }
+            Err(e) => {
+                println!("      ✗ Zlib decompression error: {}", e);
+                Err(e.into())
+            }
+        }
+    }
+
+    fn decompress_u8_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        println!("    Decompressing {} stream: {} bytes", stream_name, compressed_data.len());
+        println!("    First 16 bytes: {:02x?}", &compressed_data[..std::cmp::min(16, compressed_data.len())]);
+        
+        // Check if this looks like DEFLATE data
+        if compressed_data.len() >= 2 {
+            let header = u16::from_be_bytes([compressed_data[0], compressed_data[1]]);
+            println!("    Header: 0x{:04x}", header);
+            
+            // DEFLATE (zlib) headers: 0x789c (default), 0x78da (best compression), etc.
+            if (compressed_data[0] & 0x0F) == 0x08 && (header % 31) == 0 {
+                println!("    This looks like valid zlib data, trying DEFLATE...");
+                match self.deflate_decompress(compressed_data) {
+                    Ok(decompressed) => {
+                        println!("    ✓ DEFLATE decompression successful: {} bytes", decompressed.len());
+                        // Continue with further decoding (RLE, Huffman)
+                        return self.reverse_categorical_encoding(&decompressed, stream_name);
+                    }
+                    Err(e) => {
+                        println!("    ✗ DEFLATE failed despite good header: {}", e);
+                    }
+                }
+            } else {
+                println!("    This doesn't look like zlib data, skipping DEFLATE");
+            }
+        }
+        
+        // Not DEFLATE data, try direct decoding
+        println!("    Attempting direct categorical decoding...");
+        self.reverse_categorical_encoding(compressed_data, stream_name)
+    }
+
+    fn reverse_categorical_encoding(&self, data: &[u8], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        println!("      Reversing categorical encoding for {}", stream_name);
+        
+        // The compression applies layers in this order:
+        // 1. RLE (if beneficial)
+        // 2. Huffman (if beneficial)
+        // 3. DEFLATE (if enabled)
+        //
+        // So decompression should reverse in opposite order:
+        // 1. DEFLATE (already handled)
+        // 2. Huffman
+        // 3. RLE
+        
+        // For now, since Huffman is just a passthrough, try RLE first
+        println!("      Trying RLE decoding first...");
+        match self.try_decode_rle(data) {
+            Ok(rle_decoded) => {
+                println!("      ✓ RLE decoding successful: {} -> {} bytes", data.len(), rle_decoded.len());
+                Ok(rle_decoded)
+            }
+            Err(e) => {
+                println!("      RLE failed ({}), trying as raw data", e);
+                // If RLE fails, maybe it wasn't RLE encoded - return raw data
+                Ok(data.to_vec())
+            }
+        }
+    }
+    
+    fn try_decode_huffman(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // For now, since your Huffman encoding is simplified (just returns input),
+        // return the data as-is
+        // TODO: Implement proper Huffman decoding when you implement proper Huffman encoding
+        println!("      Huffman decode (placeholder): {} bytes", data.len());
+        Ok(data.to_vec())
+    }
+    
+    fn try_decode_rle(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut decoded = Vec::new();
+        let mut cursor = 0;
+        
+        println!("      Attempting RLE decode on {} bytes", data.len());
+        println!("      RLE data starts: {:02x?}", &data[..std::cmp::min(8, data.len())]);
+        
+        while cursor < data.len() {
+            // Save cursor position for error reporting
+            let start_cursor = cursor;
+            
+            // Try to decode varint count
+            let count = match self.decode_varint(data, &mut cursor) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("      RLE varint decode failed at cursor {} (bytes: {:02x?}): {}", 
+                        start_cursor, 
+                        &data[start_cursor..std::cmp::min(start_cursor + 8, data.len())],
+                        e
+                    );
+                    return Err(format!("RLE varint decode failed at {}: {}", start_cursor, e).into());
+                }
+            };
+            
+            if cursor >= data.len() {
+                return Err("RLE: Incomplete data, missing value byte".into());
+            }
+            
+            let value = data[cursor];
+            cursor += 1;
+            
+            // Sanity check
+            if count < 0 {
+                // Handle ZigZag decoding if needed
+                return Err(format!("RLE: Negative count: {}", count).into());
+            }
+            
+            if count > 1_000_000 {
+                return Err(format!("RLE: Count too large: {}", count).into());
+            }
+            
+            // Extend with the repeated value
+            let count_u = count as usize;
+            for _ in 0..count_u {
+                decoded.push(value);
+            }
+            
+            // Safety check
+            if decoded.len() > 10_000_000 {
+                return Err("RLE decode result too large".into());
+            }
+        }
+        
+        println!("      RLE decode successful: {} bytes", decoded.len());
+        Ok(decoded)
+    }
+
+    fn decompress_u16_stream(&self, data: &[u8], _stream_name: &str) -> Result<Vec<u16>, Box<dyn std::error::Error>> {
+        let bytes = self.deflate_decompress(data)?;
+        if bytes.len() % 2 != 0 {
+            return Err("Invalid u16 stream: odd number of bytes".into());
+        }
+        
+        Ok(bytes.chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect())
+    }
+
+    fn decompress_u32_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
+        println!("    Decompressing {} stream: {} bytes", stream_name, compressed_data.len());
+        
+        // First decompress with DEFLATE
+        let deflate_decompressed = self.deflate_decompress(compressed_data)?;
+        println!("    After DEFLATE: {} bytes", deflate_decompressed.len());
+        
+        // Then reverse varint/delta encoding
+        let values = self.decode_u32_varint_stream(&deflate_decompressed, stream_name == "run_ids")?;
+        println!("    Decoded {} u32 values", values.len());
+        
+        Ok(values)
+    }
+
+    fn decompress_coordinate_streams(&self, compressed_data: &[u8]) -> Result<(Vec<u32>, Vec<u32>, Vec<u16>), Box<dyn std::error::Error>> {
+        println!("    Decompressing coordinate streams: {} bytes", compressed_data.len());
+        
+        // First decompress with DEFLATE
+        let deflate_decompressed = self.deflate_decompress(compressed_data)?;
+        println!("    After DEFLATE: {} bytes", deflate_decompressed.len());
+        
+        // Then decode 2D delta encoding + varints
+        let (x_coords, y_coords, tiles) = self.decode_2d_coordinate_deltas(&deflate_decompressed)?;
+        println!("    Decoded {} coordinates", x_coords.len());
+        
+        Ok((x_coords, y_coords, tiles))
+    }
+
+    fn decompress_sparse_u16_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<Option<u16>>, Box<dyn std::error::Error>> {
+        println!("    Decompressing sparse {} stream: {} bytes", stream_name, compressed_data.len());
+        
+        // Sparse streams have bitmap + values format
+        let (bitmap, values) = self.decode_sparse_u16_data(compressed_data)?;
+        println!("    Decoded {} sparse u16 values", bitmap.len());
+        
+        Ok(self.reconstruct_sparse_u16_stream(&bitmap, &values))
+    }
+
+    fn decompress_sparse_u8_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<Option<u8>>, Box<dyn std::error::Error>> {
+        println!("    Decompressing sparse {} stream: {} bytes", stream_name, compressed_data.len());
+        
+        // Sparse streams have bitmap + values format  
+        let (bitmap, values) = self.decode_sparse_u8_data(compressed_data)?;
+        println!("    Decoded {} sparse u8 values", bitmap.len());
+        
+        Ok(self.reconstruct_sparse_u8_stream(&bitmap, &values))
+    }
+
+    fn decompress_optional_u16_stream(&self, data: &[u8], stream_name: &str) -> Result<Vec<Option<u16>>, Box<dyn std::error::Error>> {
+        let values = self.decompress_u16_stream(data, stream_name)?;
+        Ok(values.into_iter()
+            .map(|v| if v == 0xFFFF { None } else { Some(v) })
+            .collect())
+    }
+
+    fn decompress_optional_u8_stream(&self, data: &[u8], stream_name: &str) -> Result<Vec<Option<u8>>, Box<dyn std::error::Error>> {
+        let values = self.decompress_u8_stream(data, stream_name)?;
+        Ok(values.into_iter()
+            .map(|v| if v == 0xFF { None } else { Some(v) })
+            .collect())
+    }
+
+    fn decode_u32_varint_stream(&self, data: &[u8], use_delta: bool) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
+        let mut values = Vec::new();
+        let mut cursor = 0;
+        
+        if use_delta {
+            // First value is absolute
+            if cursor < data.len() {
+                let first = self.decode_varint(data, &mut cursor)?;
+                values.push(first as u32);
+                
+                // Remaining values are deltas
+                while cursor < data.len() {
+                    let delta = self.decode_varint(data, &mut cursor)?;
+                    let prev = *values.last().unwrap();
+                    values.push((prev as i32 + delta) as u32);
+                }
+            }
+        } else {
+            // All values are absolute
+            while cursor < data.len() {
+                let value = self.decode_varint(data, &mut cursor)?;
+                values.push(value as u32);
+            }
+        }
+        
+        Ok(values)
+    }
+
+    fn decode_2d_coordinate_deltas(&self, data: &[u8]) -> Result<(Vec<u32>, Vec<u32>, Vec<u16>), Box<dyn std::error::Error>> {
+        let mut x_coords = Vec::new();
+        let mut y_coords = Vec::new();
+        let mut tiles = Vec::new();
+        
+        let mut cursor = 0;
+        let mut last_x = 0i32;
+        let mut last_y = 0i32;
+        let mut last_tile = 0i32;
+        
+        while cursor < data.len() {
+            // Read delta triplet: dx, dy, dtile
+            let dx = self.decode_varint(data, &mut cursor)?;
+            let dy = self.decode_varint(data, &mut cursor)?;
+            let dtile = self.decode_varint(data, &mut cursor)?;
+            
+            // Apply deltas
+            last_x += dx;
+            last_y += dy;
+            last_tile += dtile;
+            
+            x_coords.push(last_x as u32);
+            y_coords.push(last_y as u32);
+            tiles.push(last_tile as u16);
+        }
+        
+        Ok((x_coords, y_coords, tiles))
+    }
+
+    fn decode_sparse_u16_data(&self, data: &[u8]) -> Result<(Vec<u8>, Vec<u16>), Box<dyn std::error::Error>> {
+        let mut cursor = 0;
+        
+        // Read bitmap size and decompress bitmap
+        let bitmap_size = self.decode_varint(data, &mut cursor)? as usize;
+        let bitmap_data = &data[cursor..cursor + bitmap_size];
+        cursor += bitmap_size;
+        let bitmap = self.deflate_decompress(bitmap_data)?;
+        
+        // Read values size and decompress values
+        let values_size = self.decode_varint(data, &mut cursor)? as usize;
+        let values_data = &data[cursor..cursor + values_size];
+        let values_bytes = self.deflate_decompress(values_data)?;
+        
+        // Decode varint values
+        let mut values = Vec::new();
+        let mut val_cursor = 0;
+        while val_cursor < values_bytes.len() {
+            let val = self.decode_varint(&values_bytes, &mut val_cursor)?;
+            values.push(val as u16);
+        }
+        
+        Ok((bitmap, values))
+    }
+
+    fn decode_sparse_u8_data(&self, data: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Box<dyn std::error::Error>> {
+        let mut cursor = 0;
+        
+        // Read bitmap size and decompress bitmap
+        let bitmap_size = self.decode_varint(data, &mut cursor)? as usize;
+        let bitmap_data = &data[cursor..cursor + bitmap_size];
+        cursor += bitmap_size;
+        let bitmap = self.deflate_decompress(bitmap_data)?;
+        
+        // Read values size and decompress values
+        let values_size = self.decode_varint(data, &mut cursor)? as usize;
+        let values_data = &data[cursor..cursor + values_size];
+        let values_bytes = self.deflate_decompress(values_data)?;
+        
+        // Decode varint values as u8
+        let mut values = Vec::new();
+        let mut val_cursor = 0;
+        while val_cursor < values_bytes.len() {
+            let val = self.decode_varint(&values_bytes, &mut val_cursor)?;
+            values.push(val as u8);
+        }
+        
+        Ok((bitmap, values))
+    }
+
+    fn reconstruct_sparse_u16_stream(&self, bitmap: &[u8], values: &[u16]) -> Vec<Option<u16>> {
+        let mut result = Vec::new();
+        let mut value_idx = 0;
+        
+        for &byte in bitmap {
+            for bit in 0..8 {
+                if (byte >> bit) & 1 == 1 {
+                    // Bit is set, use next value
+                    if value_idx < values.len() {
+                        result.push(Some(values[value_idx]));
+                        value_idx += 1;
+                    } else {
+                        result.push(None);
+                    }
+                } else {
+                    // Bit is not set, use None
+                    result.push(None);
+                }
+            }
+        }
+        
+        result
+    }
+
+    fn reconstruct_sparse_u8_stream(&self, bitmap: &[u8], values: &[u8]) -> Vec<Option<u8>> {
+        let mut result = Vec::new();
+        let mut value_idx = 0;
+        
+        for &byte in bitmap {
+            for bit in 0..8 {
+                if (byte >> bit) & 1 == 1 {
+                    // Bit is set, use next value
+                    if value_idx < values.len() {
+                        result.push(Some(values[value_idx]));
+                        value_idx += 1;
+                    } else {
+                        result.push(None);
+                    }
+                } else {
+                    // Bit is not set, use None
+                    result.push(None);
+                }
+            }
+        }
+        
+        result
+    }
+
+    
+
+    fn decompress_bytes(&self, compressed: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // Simple deflate decompression for now
+        // You can enhance this to detect compression type and use appropriate decompression
+        use flate2::read::DeflateDecoder;
+        use std::io::Read;
+        
+        let mut decoder = DeflateDecoder::new(compressed);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed)?;
+        Ok(decompressed)
+    }
+    
+    fn reconstruct_tokens(&self, streams: TokenizedStreams) -> Vec<TokenizedReadName> {
+        let count = streams.instrument_ids.len();
+        let mut tokens = Vec::with_capacity(count);
+        
+        for i in 0..count {
+            tokens.push(TokenizedReadName {
+                instrument_id: streams.instrument_ids[i],
+                run_id: streams.run_ids[i],
+                flowcell_id: streams.flowcell_ids[i],
+                lane: streams.lanes[i],
+                tile: streams.tiles[i],
+                x_coord: streams.x_coords[i],
+                y_coord: streams.y_coords[i],
+                umi_id: streams.umi_ids[i],
+                read_num: streams.read_nums[i],
+                flags: streams.flags[i],
+                index_id: streams.index_ids[i],
+            });
+        }
+        
+        tokens
+    }
     // Add remaining helper methods...
 }
 

--- a/gbam_tools/src/tokenizer_encoding/post_compression.rs
+++ b/gbam_tools/src/tokenizer_encoding/post_compression.rs
@@ -113,11 +113,8 @@ impl PostTokenizationCompressor {
     }
 
     fn compress_coordinate_streams(&self, x_coords: &[u32], y_coords: &[u32], tiles: &[u16]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        println!("Compressing coordinate streams...");
-        
         // Stage 1: 2D delta encoding
         let deltas = self.encode_2d_deltas(x_coords, y_coords, tiles);
-        println!("Coordinate deltas calculated: {} deltas", deltas.len());
         
         // Stage 2: Interleave and varint encode
         let mut compressed = Vec::new();
@@ -127,12 +124,9 @@ impl PostTokenizationCompressor {
             compressed.extend(self.encode_varint(delta.dtile as i32));
         }
         
-        println!("Coordinates after varint: {} bytes", compressed.len());
-        
         // Stage 3: Final compression
         if self.config.use_deflate {
             let deflated = self.deflate_compress(&compressed)?;
-            println!("Coordinates after DEFLATE: {} -> {} bytes", compressed.len(), deflated.len());
             compressed = deflated;
         }
         
@@ -165,8 +159,6 @@ impl PostTokenizationCompressor {
             bitmap.push(current_byte);
         }
         
-        println!("{}: bitmap {} bytes, values {} bytes", stream_name, bitmap.len(), values.len());
-        
         // Stage 2: Compress bitmap and values
         let compressed_bitmap = if self.config.use_deflate {
             self.deflate_compress(&bitmap)?
@@ -186,8 +178,7 @@ impl PostTokenizationCompressor {
         result.extend(compressed_bitmap);
         result.extend(self.encode_varint(compressed_values.len() as i32));
         result.extend(compressed_values);
-        
-        println!("{} final size: {} bytes", stream_name, result.len());
+
         Ok(result)
     }
 
@@ -359,12 +350,10 @@ impl PostTokenizationCompressor {
                 serialized.extend(item);
             }
         }
-        
-        println!("Dictionary serialized: {} bytes", serialized.len());
+
         
         if self.config.use_deflate {
             let compressed = self.deflate_compress(&serialized)?;
-            println!("Dictionary after compression: {} -> {} bytes", serialized.len(), compressed.len());
             Ok(compressed)
         } else {
             Ok(serialized)
@@ -405,8 +394,7 @@ impl PostTokenizationCompressor {
         
         block.extend(self.encode_varint(compressed_streams.index_ids.len() as i32));
         block.extend(compressed_streams.index_ids);
-        
-        println!("Final assembled block size: {} bytes", block.len());
+
         block
     }
 
@@ -441,14 +429,9 @@ impl PostTokenizationCompressor {
         dictionary: &ReadNameDictionary,
     ) -> Result<Vec<TokenizedReadName>, Box<dyn std::error::Error>> {
         
-        println!("=== POST-TOKENIZATION DECOMPRESSION DEBUG ===");
-        println!("Compressed data size: {} bytes", compressed_data.len());
-        println!("First 16 bytes: {:02x?}", &compressed_data[..std::cmp::min(16, compressed_data.len())]);
-        
         // Step 1: Parse the varint-encoded dictionary size
         let mut cursor = 0;
         let dict_size = self.decode_varint(compressed_data, &mut cursor)?;
-        println!("Dictionary size from varint: {} bytes (cursor at {})", dict_size, cursor);
         
         if dict_size < 0 || dict_size as usize > compressed_data.len() {
             return Err(format!("Invalid dictionary size: {}", dict_size).into());
@@ -461,10 +444,8 @@ impl PostTokenizationCompressor {
         if streams_start > compressed_data.len() {
             return Err("Invalid compressed data: dictionary size exceeds data length".into());
         }
-        
-        println!("Embedded dictionary: {} bytes, streams start at: {}", dict_size, streams_start);
+
         let streams_data = &compressed_data[streams_start..];
-        println!("Streams data size: {} bytes", streams_data.len());
         
         // Step 3: Decompress all streams
         let streams = self.decompress_all_streams(streams_data)?;
@@ -474,13 +455,10 @@ impl PostTokenizationCompressor {
     }
 
     fn decompress_all_streams(&self, streams_data: &[u8]) -> Result<TokenizedStreams, Box<dyn std::error::Error>> {
-        println!("\n=== Decompressing Individual Streams ===");
         let mut cursor = 0;
         
         // Stream 1: instrument_ids
-        println!("Decompressing instrument_ids stream...");
         let instrument_ids_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", instrument_ids_size);
         if cursor + instrument_ids_size as usize > streams_data.len() {
             return Err(format!("instrument_ids stream exceeds data bounds").into());
         }
@@ -489,9 +467,7 @@ impl PostTokenizationCompressor {
         let instrument_ids = self.decompress_u8_stream(instrument_ids_data, "instrument_ids")?;
         
         // Stream 2: run_ids
-        println!("Decompressing run_ids stream...");
         let run_ids_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", run_ids_size);
         if cursor + run_ids_size as usize > streams_data.len() {
             return Err(format!("run_ids stream exceeds data bounds").into());
         }
@@ -500,9 +476,7 @@ impl PostTokenizationCompressor {
         let run_ids = self.decompress_u32_stream(run_ids_data, "run_ids")?;
         
         // Stream 3: flowcell_ids
-        println!("Decompressing flowcell_ids stream...");
         let flowcell_ids_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", flowcell_ids_size);
         if cursor + flowcell_ids_size as usize > streams_data.len() {
             return Err(format!("flowcell_ids stream exceeds data bounds").into());
         }
@@ -511,9 +485,7 @@ impl PostTokenizationCompressor {
         let flowcell_ids = self.decompress_u8_stream(flowcell_ids_data, "flowcell_ids")?;
         
         // Stream 4: lanes
-        println!("Decompressing lanes stream...");
         let lanes_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", lanes_size);
         if cursor + lanes_size as usize > streams_data.len() {
             return Err(format!("lanes stream exceeds data bounds").into());
         }
@@ -522,9 +494,7 @@ impl PostTokenizationCompressor {
         let lanes = self.decompress_u8_stream(lanes_data, "lanes")?;
         
         // Stream 5: read_nums
-        println!("Decompressing read_nums stream...");
         let read_nums_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", read_nums_size);
         if cursor + read_nums_size as usize > streams_data.len() {
             return Err(format!("read_nums stream exceeds data bounds").into());
         }
@@ -533,9 +503,7 @@ impl PostTokenizationCompressor {
         let read_nums = self.decompress_u8_stream(read_nums_data, "read_nums")?;
         
         // Stream 6: flags
-        println!("Decompressing flags stream...");
         let flags_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", flags_size);
         if cursor + flags_size as usize > streams_data.len() {
             return Err(format!("flags stream exceeds data bounds").into());
         }
@@ -544,9 +512,7 @@ impl PostTokenizationCompressor {
         let flags = self.decompress_u8_stream(flags_data, "flags")?;
         
         // Stream 7: coordinates (combined x_coords, y_coords, tiles)
-        println!("Decompressing coordinates stream...");
         let coordinates_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", coordinates_size);
         if cursor + coordinates_size as usize > streams_data.len() {
             return Err(format!("coordinates stream exceeds data bounds").into());
         }
@@ -555,9 +521,7 @@ impl PostTokenizationCompressor {
         let (x_coords, y_coords, tiles) = self.decompress_coordinate_streams(coordinates_data)?;
         
         // Stream 8: umi_ids (sparse)
-        println!("Decompressing umi_ids stream...");
         let umi_ids_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", umi_ids_size);
         if cursor + umi_ids_size as usize > streams_data.len() {
             return Err(format!("umi_ids stream exceeds data bounds").into());
         }
@@ -566,18 +530,13 @@ impl PostTokenizationCompressor {
         let umi_ids = self.decompress_sparse_u16_stream(umi_ids_data, "umi_ids")?;
         
         // Stream 9: index_ids (sparse)
-        println!("Decompressing index_ids stream...");
         let index_ids_size = self.decode_varint(streams_data, &mut cursor)?;
-        println!("  Size: {} bytes", index_ids_size);
         if cursor + index_ids_size as usize > streams_data.len() {
             return Err(format!("index_ids stream exceeds data bounds").into());
         }
         let index_ids_data = &streams_data[cursor..cursor + index_ids_size as usize];
         cursor += index_ids_size as usize;
         let index_ids = self.decompress_sparse_u8_stream(index_ids_data, "index_ids")?;
-        
-        println!("All streams decompressed successfully");
-        println!("Final cursor position: {} / {}", cursor, streams_data.len());
         
         Ok(TokenizedStreams {
             instrument_ids,
@@ -598,38 +557,28 @@ impl PostTokenizationCompressor {
         use flate2::read::ZlibDecoder;
         use std::io::Read;
         
-        println!("      Attempting zlib decompression on {} bytes", data.len());
-        println!("      Data starts with: {:02x?}", &data[..std::cmp::min(8, data.len())]);
-        
         let mut decoder = ZlibDecoder::new(data);
         let mut decompressed = Vec::new();
         match decoder.read_to_end(&mut decompressed) {
             Ok(bytes_read) => {
-                println!("      ✓ Zlib decompression successful: {} bytes read", bytes_read);
                 Ok(decompressed)
             }
             Err(e) => {
-                println!("      ✗ Zlib decompression error: {}", e);
                 Err(e.into())
             }
         }
     }
 
     fn decompress_u8_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        println!("    Decompressing {} stream: {} bytes", stream_name, compressed_data.len());
-        println!("    First 16 bytes: {:02x?}", &compressed_data[..std::cmp::min(16, compressed_data.len())]);
         
         // Check if this looks like DEFLATE data
         if compressed_data.len() >= 2 {
             let header = u16::from_be_bytes([compressed_data[0], compressed_data[1]]);
-            println!("    Header: 0x{:04x}", header);
             
             // DEFLATE (zlib) headers: 0x789c (default), 0x78da (best compression), etc.
             if (compressed_data[0] & 0x0F) == 0x08 && (header % 31) == 0 {
-                println!("    This looks like valid zlib data, trying DEFLATE...");
                 match self.deflate_decompress(compressed_data) {
                     Ok(decompressed) => {
-                        println!("    ✓ DEFLATE decompression successful: {} bytes", decompressed.len());
                         // Continue with further decoding (RLE, Huffman)
                         return self.reverse_categorical_encoding(&decompressed, stream_name);
                     }
@@ -643,13 +592,10 @@ impl PostTokenizationCompressor {
         }
         
         // Not DEFLATE data, try direct decoding
-        println!("    Attempting direct categorical decoding...");
         self.reverse_categorical_encoding(compressed_data, stream_name)
     }
 
     fn reverse_categorical_encoding(&self, data: &[u8], stream_name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        println!("      Reversing categorical encoding for {}", stream_name);
-        
         // The compression applies layers in this order:
         // 1. RLE (if beneficial)
         // 2. Huffman (if beneficial)
@@ -661,14 +607,11 @@ impl PostTokenizationCompressor {
         // 3. RLE
         
         // For now, since Huffman is just a passthrough, try RLE first
-        println!("      Trying RLE decoding first...");
         match self.try_decode_rle(data) {
             Ok(rle_decoded) => {
-                println!("      ✓ RLE decoding successful: {} -> {} bytes", data.len(), rle_decoded.len());
                 Ok(rle_decoded)
             }
             Err(e) => {
-                println!("      RLE failed ({}), trying as raw data", e);
                 // If RLE fails, maybe it wasn't RLE encoded - return raw data
                 Ok(data.to_vec())
             }
@@ -676,19 +619,15 @@ impl PostTokenizationCompressor {
     }
     
     fn try_decode_huffman(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        // For now, since your Huffman encoding is simplified (just returns input),
+        // For now, since Huffman encoding is simplified (just returns input),
         // return the data as-is
-        // TODO: Implement proper Huffman decoding when you implement proper Huffman encoding
-        println!("      Huffman decode (placeholder): {} bytes", data.len());
+        // TODO: Implement proper Huffman decoding when we implement proper Huffman encoding
         Ok(data.to_vec())
     }
     
     fn try_decode_rle(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut decoded = Vec::new();
         let mut cursor = 0;
-        
-        println!("      Attempting RLE decode on {} bytes", data.len());
-        println!("      RLE data starts: {:02x?}", &data[..std::cmp::min(8, data.len())]);
         
         while cursor < data.len() {
             // Save cursor position for error reporting
@@ -698,11 +637,6 @@ impl PostTokenizationCompressor {
             let count = match self.decode_varint(data, &mut cursor) {
                 Ok(c) => c,
                 Err(e) => {
-                    println!("      RLE varint decode failed at cursor {} (bytes: {:02x?}): {}", 
-                        start_cursor, 
-                        &data[start_cursor..std::cmp::min(start_cursor + 8, data.len())],
-                        e
-                    );
                     return Err(format!("RLE varint decode failed at {}: {}", start_cursor, e).into());
                 }
             };
@@ -735,8 +669,6 @@ impl PostTokenizationCompressor {
                 return Err("RLE decode result too large".into());
             }
         }
-        
-        println!("      RLE decode successful: {} bytes", decoded.len());
         Ok(decoded)
     }
 
@@ -752,49 +684,37 @@ impl PostTokenizationCompressor {
     }
 
     fn decompress_u32_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
-        println!("    Decompressing {} stream: {} bytes", stream_name, compressed_data.len());
-        
         // First decompress with DEFLATE
         let deflate_decompressed = self.deflate_decompress(compressed_data)?;
-        println!("    After DEFLATE: {} bytes", deflate_decompressed.len());
         
         // Then reverse varint/delta encoding
         let values = self.decode_u32_varint_stream(&deflate_decompressed, stream_name == "run_ids")?;
-        println!("    Decoded {} u32 values", values.len());
         
         Ok(values)
     }
 
     fn decompress_coordinate_streams(&self, compressed_data: &[u8]) -> Result<(Vec<u32>, Vec<u32>, Vec<u16>), Box<dyn std::error::Error>> {
-        println!("    Decompressing coordinate streams: {} bytes", compressed_data.len());
-        
         // First decompress with DEFLATE
         let deflate_decompressed = self.deflate_decompress(compressed_data)?;
-        println!("    After DEFLATE: {} bytes", deflate_decompressed.len());
         
         // Then decode 2D delta encoding + varints
         let (x_coords, y_coords, tiles) = self.decode_2d_coordinate_deltas(&deflate_decompressed)?;
-        println!("    Decoded {} coordinates", x_coords.len());
         
         Ok((x_coords, y_coords, tiles))
     }
 
     fn decompress_sparse_u16_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<Option<u16>>, Box<dyn std::error::Error>> {
-        println!("    Decompressing sparse {} stream: {} bytes", stream_name, compressed_data.len());
         
         // Sparse streams have bitmap + values format
         let (bitmap, values) = self.decode_sparse_u16_data(compressed_data)?;
-        println!("    Decoded {} sparse u16 values", bitmap.len());
         
         Ok(self.reconstruct_sparse_u16_stream(&bitmap, &values))
     }
 
     fn decompress_sparse_u8_stream(&self, compressed_data: &[u8], stream_name: &str) -> Result<Vec<Option<u8>>, Box<dyn std::error::Error>> {
-        println!("    Decompressing sparse {} stream: {} bytes", stream_name, compressed_data.len());
         
         // Sparse streams have bitmap + values format  
         let (bitmap, values) = self.decode_sparse_u8_data(compressed_data)?;
-        println!("    Decoded {} sparse u8 values", bitmap.len());
         
         Ok(self.reconstruct_sparse_u8_stream(&bitmap, &values))
     }

--- a/gbam_tools/src/tokenizer_encoding/tokenizer.rs
+++ b/gbam_tools/src/tokenizer_encoding/tokenizer.rs
@@ -1,0 +1,502 @@
+//! Illumina read name tokenizer implementation
+
+use super::{
+    error::TokenizationError,
+    dictionary::{ReadNameDictionary, TokenizedReadName},
+    utils::ByteUtils,
+    TokenizationStats,
+};
+
+pub struct IlluminaTokenizer {
+    dictionary: ReadNameDictionary,
+    total_reads_processed: usize,
+    successfully_tokenized: usize,
+}
+
+impl IlluminaTokenizer {
+    pub fn new() -> Self {
+        Self {
+            dictionary: ReadNameDictionary::new(),
+            total_reads_processed: 0,
+            successfully_tokenized: 0,
+        }
+    }
+
+    pub fn with_dictionary(dictionary: ReadNameDictionary) -> Self {
+        Self { 
+            dictionary,
+            total_reads_processed: 0,
+            successfully_tokenized: 0,
+        }
+    }
+
+    pub fn tokenize_batch(&mut self, read_names: &[&[u8]]) -> Result<Vec<TokenizedReadName>, TokenizationError> {
+        let mut results = Vec::with_capacity(read_names.len());
+        
+        for (index, name) in read_names.iter().enumerate() {
+            self.total_reads_processed += 1;
+            match self.tokenize_single(name) {
+                Ok(tokenized) => {
+                    self.successfully_tokenized += 1;
+                    results.push(tokenized);
+                },
+                Err(e) => return Err(TokenizationError::ParseError(
+                    format!("Failed to tokenize read {} ({}): {}", index, ByteUtils::bytes_to_string_lossy(name), e)
+                )),
+            }
+        }
+        
+        Ok(results)
+    }
+
+    pub fn tokenize_single(&mut self, read_name: &[u8]) -> Result<TokenizedReadName, TokenizationError> {
+        let name_str = std::str::from_utf8(read_name)
+            .map_err(|e| TokenizationError::ParseError(e.to_string()))?;
+        
+        // Try modern Illumina format first
+        if let Ok(tokenized) = self.parse_modern_illumina(name_str) {
+            return Ok(tokenized);
+        }
+        
+        // Try legacy Illumina format
+        if let Ok(tokenized) = self.parse_legacy_illumina(name_str) {
+            return Ok(tokenized);
+        }
+        
+        Err(TokenizationError::InvalidFormat(
+            format!("Unrecognized Illumina format: {}", name_str)
+        ))
+    }
+
+    // Modern Illumina format: INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y UMI:READ:FLAGS:INDEX
+    // Fix the parse_modern_illumina method around line 81:
+    fn parse_modern_illumina(&mut self, name_str: &str) -> Result<TokenizedReadName, TokenizationError> {
+        let parts: Vec<&str> = name_str.split([':', ' ']).collect();
+        
+        if parts.len() < 7 {
+            return Err(TokenizationError::InvalidFormat("Not modern Illumina format".to_string()));
+        }
+
+        let instrument_id = self.dictionary.add_instrument(parts[0].as_bytes());
+        let run_id: u32 = parts[1].parse::<u32>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let flowcell_id = self.dictionary.add_flowcell(parts[2].as_bytes());
+        let lane: u8 = parts[3].parse::<u8>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let tile: u16 = parts[4].parse::<u16>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let x_coord: u32 = parts[5].parse::<u32>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let y_coord: u32 = parts[6].parse::<u32>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+
+        // Optional fields
+        let umi_id = if parts.len() > 7 && !parts[7].is_empty() {
+            Some(self.dictionary.add_umi(parts[7].as_bytes()))
+        } else {
+            None
+        };
+
+        let read_num = if parts.len() > 8 {
+            parts[8].parse().unwrap_or(1)
+        } else {
+            1
+        };
+
+        let flags = if parts.len() > 9 {
+            self.parse_flags_from_string(parts[9])
+        } else {
+            0
+        };
+
+        let index_id = if parts.len() > 10 && !parts[10].is_empty() {
+            Some(self.dictionary.add_index(parts[10].as_bytes()))
+        } else {
+            None
+        };
+
+        Ok(TokenizedReadName {
+            instrument_id,
+            run_id,
+            flowcell_id,
+            lane,
+            tile,
+            x_coord,
+            y_coord,
+            umi_id,
+            read_num,
+            flags,
+            index_id,
+        })
+    }
+
+    // Fix the parse_legacy_illumina method around line 156:
+    fn parse_legacy_illumina(&mut self, name_str: &str) -> Result<TokenizedReadName, TokenizationError> {
+        // Split by '#' first to separate index/UMI part
+        let main_parts: Vec<&str> = name_str.split('#').collect();
+        let coordinate_part = main_parts[0];
+        
+        // Parse the main coordinate part
+        let parts: Vec<&str> = coordinate_part.split(':').collect();
+        
+        if parts.len() != 5 {
+            return Err(TokenizationError::InvalidFormat(
+                format!("Legacy format should have 5 colon-separated parts, got {}", parts.len())
+            ));
+        }
+
+        // Parse instrument_run (like "HWUSI-EAS566_0007")
+        let instrument_run = parts[0];
+        let instrument_id = self.dictionary.add_instrument(instrument_run.as_bytes());
+        
+        // For legacy format, we don't have separate run ID, so use a hash of the instrument
+        let run_id = self.hash_string(instrument_run);
+        
+        // Parse lane, tile, x, y
+        let lane: u8 = parts[1].parse::<u8>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let tile: u16 = parts[2].parse::<u16>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let x_coord: u32 = parts[3].parse::<u32>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+        let y_coord: u32 = parts[4].parse::<u32>()
+            .map_err(|e: std::num::ParseIntError| TokenizationError::ParseError(e.to_string()))?;
+
+        // Parse index and UMI from the suffix (if present)
+        let (index_id, umi_id) = if main_parts.len() > 1 {
+            let suffix = main_parts[1];
+            if let Some(umi_pos) = suffix.find('|') {
+                // Format: #INDEX|UMI
+                let index_part = &suffix[..umi_pos];
+                let umi_part = &suffix[umi_pos + 1..];
+                
+                let index_id = if !index_part.is_empty() {
+                    Some(self.dictionary.add_index(index_part.as_bytes()))
+                } else {
+                    None
+                };
+                
+                let umi_id = if !umi_part.is_empty() {
+                    Some(self.dictionary.add_umi(umi_part.as_bytes()))
+                } else {
+                    None
+                };
+                
+                (index_id, umi_id)
+            } else {
+                // Just index, no UMI
+                let index_id = if !suffix.is_empty() {
+                    Some(self.dictionary.add_index(suffix.as_bytes()))
+                } else {
+                    None
+                };
+                (index_id, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        Ok(TokenizedReadName {
+            instrument_id,
+            run_id,
+            flowcell_id: 0, // Legacy format doesn't have separate flowcell ID
+            lane,
+            tile,
+            x_coord,
+            y_coord,
+            umi_id,
+            read_num: 1,
+            flags: 0,
+            index_id,
+        })
+    }
+
+    fn parse_flags_from_string(&self, flags_str: &str) -> u8 {
+        // Parse flags like "Y", "N", "0", "1", etc.
+        match flags_str {
+            "Y" => 1,
+            "N" => 0,
+            _ => flags_str.parse().unwrap_or(0),
+        }
+    }
+
+    fn hash_string(&self, s: &str) -> u32 {
+        let mut hash = 0u32;
+        for byte in s.bytes() {
+            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
+        }
+        hash
+    }
+
+    pub fn detokenize(&self, tokenized: &TokenizedReadName) -> Result<Vec<u8>, TokenizationError> {
+        let instrument = self.dictionary.get_instrument(tokenized.instrument_id)
+            .ok_or_else(|| TokenizationError::InvalidFormat(
+                format!("Instrument ID {} not found", tokenized.instrument_id)
+            ))?;
+        
+        let mut name = Vec::new();
+        
+        // Build the read name - handle legacy format differently
+        name.extend_from_slice(instrument);
+        
+        if tokenized.flowcell_id == 0 {
+            // Legacy format: INSTRUMENT:LANE:TILE:X:Y#INDEX|UMI
+            name.push(b':');
+            name.extend_from_slice(tokenized.lane.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.tile.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.x_coord.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.y_coord.to_string().as_bytes());
+            
+            // Add index and UMI if present
+            if tokenized.index_id.is_some() || tokenized.umi_id.is_some() {
+                name.push(b'#');
+                
+                if let Some(index_id) = tokenized.index_id {
+                    if let Some(index) = self.dictionary.get_index(index_id) {
+                        name.extend_from_slice(index);
+                    }
+                }
+                
+                if let Some(umi_id) = tokenized.umi_id {
+                    if let Some(umi) = self.dictionary.get_umi(umi_id) {
+                        name.push(b'|');
+                        name.extend_from_slice(umi);
+                    }
+                }
+            }
+        } else {
+            // Modern format: INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y
+            name.push(b':');
+            name.extend_from_slice(tokenized.run_id.to_string().as_bytes());
+            
+            if let Some(flowcell) = self.dictionary.get_flowcell(tokenized.flowcell_id) {
+                name.push(b':');
+                name.extend_from_slice(flowcell);
+            }
+            
+            name.push(b':');
+            name.extend_from_slice(tokenized.lane.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.tile.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.x_coord.to_string().as_bytes());
+            name.push(b':');
+            name.extend_from_slice(tokenized.y_coord.to_string().as_bytes());
+
+            // Add UMI if present
+            if let Some(umi_id) = tokenized.umi_id {
+                if let Some(umi) = self.dictionary.get_umi(umi_id) {
+                    name.push(b':');
+                    name.extend_from_slice(umi);
+                }
+            }
+
+            // Add read number
+            name.push(b':');
+            name.extend_from_slice(tokenized.read_num.to_string().as_bytes());
+
+            // Add flags
+            name.push(b':');
+            name.push(if tokenized.flags & 0x01 != 0 { b'Y' } else { b'N' });
+
+            // Add index if present
+            if let Some(index_id) = tokenized.index_id {
+                if let Some(index) = self.dictionary.get_index(index_id) {
+                    name.push(b':');
+                    name.extend_from_slice(index);
+                }
+            }
+        }
+
+        Ok(name)
+    }
+
+    pub fn get_dictionary(&self) -> &ReadNameDictionary {
+        &self.dictionary
+    }
+
+    pub fn get_dictionary_mut(&mut self) -> &mut ReadNameDictionary {
+        &mut self.dictionary
+    }
+
+    pub fn dictionary_size(&self) -> usize {
+        let (instruments, flowcells, umis, indices) = self.dictionary.entry_counts();
+        instruments + flowcells + umis + indices
+    }
+
+    pub fn serialize_dictionary(&self) -> Vec<u8> {
+        // Simple serialization for testing
+        let mut result = Vec::new();
+        
+        // Serialize instruments
+        result.extend_from_slice(&(self.dictionary.instruments.len() as u32).to_le_bytes());
+        for instrument in &self.dictionary.instruments {
+            result.extend_from_slice(&(instrument.len() as u32).to_le_bytes());
+            result.extend_from_slice(instrument);
+        }
+        
+        // Serialize flowcells
+        result.extend_from_slice(&(self.dictionary.flowcells.len() as u32).to_le_bytes());
+        for flowcell in &self.dictionary.flowcells {
+            result.extend_from_slice(&(flowcell.len() as u32).to_le_bytes());
+            result.extend_from_slice(flowcell);
+        }
+        
+        // Serialize UMIs
+        result.extend_from_slice(&(self.dictionary.umis.len() as u32).to_le_bytes());
+        for umi in &self.dictionary.umis {
+            result.extend_from_slice(&(umi.len() as u32).to_le_bytes());
+            result.extend_from_slice(umi);
+        }
+        
+        // Serialize indices
+        result.extend_from_slice(&(self.dictionary.indices.len() as u32).to_le_bytes());
+        for index in &self.dictionary.indices {
+            result.extend_from_slice(&(index.len() as u32).to_le_bytes());
+            result.extend_from_slice(index);
+        }
+        
+        result
+    }
+
+    pub fn get_stats(&self) -> TokenizationStats {
+        TokenizationStats {
+            total_reads: self.total_reads_processed,
+            successfully_tokenized: self.successfully_tokenized,
+            dictionary_size: self.dictionary.total_size(),
+            compression_ratio: if self.total_reads_processed > 0 {
+                self.successfully_tokenized as f64 / self.total_reads_processed as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    pub fn calculate_compression_stats(&self, original_names: &[&[u8]], tokenized: &[TokenizedReadName]) -> CompressionStats {
+        let original_size: usize = original_names.iter().map(|name| name.len()).sum();
+        
+        // Calculate tokenized size: each TokenizedReadName is approximately 19 bytes
+        // instrument_id (1) + run_id (4) + flowcell_id (1) + lane (1) + tile (2) + 
+        // x_coord (4) + y_coord (4) + umi_id opt (2) + read_num (1) + flags (1) + index_id opt (1) = ~22 bytes
+        let tokenized_size = tokenized.len() * 22;
+        
+        let dictionary_size = self.dictionary.total_size();
+        let total_compressed_size = tokenized_size + dictionary_size;
+        
+        CompressionStats {
+            total_reads: original_names.len(),
+            original_size,
+            tokenized_size,
+            dictionary_size,
+            compression_ratio: if total_compressed_size > 0 {
+                original_size as f64 / total_compressed_size as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    pub fn reset_stats(&mut self) {
+        self.total_reads_processed = 0;
+        self.successfully_tokenized = 0;
+    }
+
+    pub fn clear_dictionary(&mut self) {
+        self.dictionary = ReadNameDictionary::new();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let (instruments, flowcells, umis, indices) = self.dictionary.entry_counts();
+        instruments == 0 && flowcells == 0 && umis == 0 && indices == 0
+    }
+}
+
+impl Default for IlluminaTokenizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Support structures for the compressor integration
+#[derive(Debug, Clone)]
+pub struct CompressionStats {
+    pub total_reads: usize,
+    pub original_size: usize,
+    pub tokenized_size: usize,
+    pub dictionary_size: usize,
+    pub compression_ratio: f64,
+}
+
+// Simplified dictionary for display purposes (for compressor compatibility)
+#[derive(Debug, Clone)]
+pub struct ReadNameDictionaryDisplay {
+    pub instruments: Vec<Vec<u8>>,
+    pub flowcells: Vec<Vec<u8>>,
+}
+
+// Helper method to convert for display
+impl IlluminaTokenizer {
+    pub fn get_dictionary_for_display(&self) -> ReadNameDictionaryDisplay {
+        ReadNameDictionaryDisplay {
+            instruments: self.dictionary.instruments.clone(),
+            flowcells: self.dictionary.flowcells.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_legacy_illumina_format() {
+        let mut tokenizer = IlluminaTokenizer::new();
+        let read_name = b"HWUSI-EAS566_0007:2:30:18804:9636#0|AGC";
+        
+        let result = tokenizer.tokenize_single(read_name);
+        assert!(result.is_ok());
+        
+        let tokenized = result.unwrap();
+        assert_eq!(tokenized.lane, 2);
+        assert_eq!(tokenized.tile, 30);
+        assert_eq!(tokenized.x_coord, 18804);
+        assert_eq!(tokenized.y_coord, 9636);
+        assert_eq!(tokenized.flowcell_id, 0); // Legacy format uses 0
+    }
+
+    #[test]
+    fn test_modern_illumina_format() {
+        let mut tokenizer = IlluminaTokenizer::new();
+        let read_name = b"INSTRUMENT:123:FLOWCELL:1:1234:5678:9012";
+        
+        let result = tokenizer.tokenize_single(read_name);
+        assert!(result.is_ok());
+        
+        let tokenized = result.unwrap();
+        assert_eq!(tokenized.lane, 1);
+        assert_eq!(tokenized.tile, 1234);
+        assert_eq!(tokenized.x_coord, 5678);
+        assert_eq!(tokenized.y_coord, 9012);
+        assert_ne!(tokenized.flowcell_id, 0); // Modern format has flowcell ID
+    }
+
+    #[test]
+    fn test_batch_tokenization() {
+        let mut tokenizer = IlluminaTokenizer::new();
+        let read_names = vec![
+            b"HWUSI-EAS566_0007:2:30:18804:9636#0|AGC".as_slice(),
+            b"HWUSI-EAS566_0007:2:30:18804:9637#0|AGC".as_slice(),
+        ];
+        
+        let result = tokenizer.tokenize_batch(&read_names);
+        assert!(result.is_ok());
+        
+        let tokenized = result.unwrap();
+        assert_eq!(tokenized.len(), 2);
+        assert_eq!(tokenized[0].y_coord, 9636);
+        assert_eq!(tokenized[1].y_coord, 9637);
+    }
+}

--- a/gbam_tools/src/tokenizer_encoding/types.rs
+++ b/gbam_tools/src/tokenizer_encoding/types.rs
@@ -1,0 +1,79 @@
+//! Core data types for read name tokenization
+
+use std::fmt;
+
+/// Tokenized representation of a sequencing read name
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TokenizedReadName {
+    pub instrument_id: u8,
+    pub run_id: u32,
+    pub flowcell_id: u8,
+    pub lane: u8,
+    pub tile: u16,
+    pub x_coord: u32,
+    pub y_coord: u32,
+    pub umi_id: Option<u16>,
+    pub read_num: u8,
+    pub flags: u8,
+    pub index_id: Option<u8>,
+}
+
+impl TokenizedReadName {
+    /// Get the size in bytes of this tokenized read name
+    pub fn size_bytes() -> usize {
+        std::mem::size_of::<Self>()
+    }
+}
+
+/// Delta-encoded coordinates for space efficiency
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoordinateDeltas {
+    pub x_delta: i16,
+    pub y_delta: i16,
+    pub tile_delta: i16,
+}
+
+/// Detected pattern types for read names
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadNamePattern {
+    /// Illumina sequencing platform pattern
+    Illumina,
+    /// PacBio sequencing platform pattern
+    PacBio,
+    /// Custom pattern with some structure
+    Custom,
+    /// Unstructured read names (no tokenization benefit)
+    Unstructured,
+}
+
+impl fmt::Display for ReadNamePattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReadNamePattern::Illumina => write!(f, "Illumina"),
+            ReadNamePattern::PacBio => write!(f, "PacBio"),
+            ReadNamePattern::Custom => write!(f, "Custom"),
+            ReadNamePattern::Unstructured => write!(f, "Unstructured"),
+        }
+    }
+}
+
+/// Statistics about the tokenization process
+#[derive(Debug, Clone)]
+pub struct TokenizationStats {
+    pub total_reads: usize,
+    pub successfully_tokenized: usize,
+    pub dictionary_size: usize,
+    pub compression_ratio: f64,
+}
+
+impl fmt::Display for TokenizationStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, 
+            "TokenizationStats {{ total_reads: {}, tokenized: {}, dict_size: {} bytes, ratio: {:.2}x }}",
+            self.total_reads, 
+            self.successfully_tokenized, 
+            self.dictionary_size, 
+            self.compression_ratio
+        )
+    }
+}

--- a/gbam_tools/src/tokenizer_encoding/utils.rs
+++ b/gbam_tools/src/tokenizer_encoding/utils.rs
@@ -1,0 +1,141 @@
+//! Utility functions for byte manipulation and parsing
+
+use std::collections::HashSet;
+
+pub struct ByteUtils;
+
+impl ByteUtils {
+    /// Convert &[u8] to String, handling invalid UTF-8 gracefully
+    pub fn bytes_to_string(bytes: &[u8]) -> Result<String, std::str::Utf8Error> {
+        std::str::from_utf8(bytes).map(|s| s.to_string())
+    }
+
+    /// Convert &[u8] to String, replacing invalid UTF-8 with replacement chars
+    pub fn bytes_to_string_lossy(bytes: &[u8]) -> String {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+
+    /// Split bytes on a delimiter
+    pub fn split_bytes(bytes: &[u8], delimiter: u8) -> Vec<&[u8]> {
+        let mut parts = Vec::new();
+        let mut start = 0;
+        
+        for (i, &byte) in bytes.iter().enumerate() {
+            if byte == delimiter {
+                parts.push(&bytes[start..i]);
+                start = i + 1;
+            }
+        }
+        
+        // Add the last part
+        if start <= bytes.len() {
+            parts.push(&bytes[start..]);
+        }
+        
+        parts
+    }
+
+    /// Parse bytes to u32
+    pub fn parse_u32(bytes: &[u8]) -> Result<u32, std::num::ParseIntError> {
+        std::str::from_utf8(bytes)
+            .map_err(|_| "0".parse::<u32>().unwrap_err())?
+            .parse::<u32>()
+    }
+
+    /// Parse bytes to u16
+    pub fn parse_u16(bytes: &[u8]) -> Result<u16, std::num::ParseIntError> {
+        std::str::from_utf8(bytes)
+            .map_err(|_| "0".parse::<u16>().unwrap_err())?
+            .parse::<u16>()
+    }
+
+    /// Parse bytes to u8
+    pub fn parse_u8(bytes: &[u8]) -> Result<u8, std::num::ParseIntError> {
+        std::str::from_utf8(bytes)
+            .map_err(|_| "0".parse::<u8>().unwrap_err())?
+            .parse::<u8>()
+    }
+
+    /// Find common prefix length between two byte slices
+    pub fn common_prefix_length(a: &[u8], b: &[u8]) -> usize {
+        a.iter()
+            .zip(b.iter())
+            .take_while(|(x, y)| x == y)
+            .count()
+    }
+
+    /// Count occurrences of a byte in a slice
+    pub fn count_byte(haystack: &[u8], needle: u8) -> usize {
+        haystack.iter().filter(|&&b| b == needle).count()
+    }
+
+    /// Calculate redundancy in a collection of byte slices
+    pub fn calculate_redundancy(data: &[&[u8]]) -> f64 {
+        let total_bytes: usize = data.iter().map(|s| s.len()).sum();
+        if total_bytes == 0 {
+            return 0.0;
+        }
+
+        let unique_bytes: HashSet<u8> = data.iter()
+            .flat_map(|s| s.iter())
+            .cloned()
+            .collect();
+        
+        1.0 - (unique_bytes.len() as f64 / total_bytes as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_bytes() {
+        let input = b"hello:world:test";
+        let parts = ByteUtils::split_bytes(input, b':');
+        
+        // Convert to Vec<Vec<u8>> for easier comparison
+        let parts_vec: Vec<Vec<u8>> = parts.iter().map(|&slice| slice.to_vec()).collect();
+        let expected = vec![
+            b"hello".to_vec(),
+            b"world".to_vec(), 
+            b"test".to_vec()
+        ];
+        
+        assert_eq!(parts_vec, expected);
+    }
+
+    #[test]
+    fn test_split_bytes_alternative() {
+        let input = b"hello:world:test";
+        let parts = ByteUtils::split_bytes(input, b':');
+        
+        // Compare each part individually
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], b"hello");
+        assert_eq!(parts[1], b"world");
+        assert_eq!(parts[2], b"test");
+    }
+
+    #[test]
+    fn test_parse_functions() {
+        assert_eq!(ByteUtils::parse_u8(b"123").unwrap(), 123);
+        assert_eq!(ByteUtils::parse_u16(b"1234").unwrap(), 1234);
+        assert_eq!(ByteUtils::parse_u32(b"12345").unwrap(), 12345);
+        
+        // Test error cases
+        assert!(ByteUtils::parse_u8(b"256").is_err()); // Too large for u8
+        assert!(ByteUtils::parse_u8(b"abc").is_err()); // Not a number
+    }
+
+    #[test]
+    fn test_bytes_to_string_lossy() {
+        let valid_utf8 = b"hello world";
+        assert_eq!(ByteUtils::bytes_to_string_lossy(valid_utf8), "hello world");
+        
+        // Test with invalid UTF-8
+        let invalid_utf8 = &[0xFF, 0xFE, 0xFD];
+        let result = ByteUtils::bytes_to_string_lossy(invalid_utf8);
+        assert!(!result.is_empty()); // Should produce some replacement characters
+    }
+}

--- a/gbam_tools/src/writer.rs
+++ b/gbam_tools/src/writer.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 use serde_json::Value;
 use std::str::FromStr;
 
+use crate::tokenizer_encoding::{IlluminaTokenizer, ReadNameAnalyzer, ReadNamePattern};
+
 pub(crate) struct BlockInfo {
     pub numitems: u32,
     pub uncompr_size: usize,

--- a/gbam_tools/src/writer.rs
+++ b/gbam_tools/src/writer.rs
@@ -1,5 +1,5 @@
 use super::meta::{BlockMeta, Codecs, FileInfo, FileMeta, Stat, FILE_INFO_SIZE};
-use crate::compressor::{CompressTask, Compressor, OrderingKey};
+use crate::compressor::{CompressTask, Compressor, OrderingKey, DictionaryAction};
 use crate::{SIZE_LIMIT, U32_SIZE};
 use bam_tools::record::bamrawrecord::BAMRawRecord;
 use bam_tools::record::fields::{
@@ -16,10 +16,12 @@ use once_cell::sync::Lazy;
 use std::fs;
 use std::path::Path;
 use serde_json::Value;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
 
 use crate::tokenizer_encoding::{IlluminaTokenizer, ReadNameAnalyzer, ReadNamePattern};
 
+#[derive(Deserialize, Serialize, Clone)]
 pub(crate) struct BlockInfo {
     pub numitems: u32,
     pub uncompr_size: usize,
@@ -27,6 +29,11 @@ pub(crate) struct BlockInfo {
     // Interpretation is up to the reader.
     pub stats: Option<Stat>,
     pub codec: Codecs,
+    #[serde(default)]
+    pub dictionary_id: Option<u32>, // Reference to dictionary in FileMeta
+    
+    #[serde(default)]
+    pub is_tokenized: bool,
 }
 
 impl Default for BlockInfo {
@@ -37,6 +44,8 @@ impl Default for BlockInfo {
             field: Fields::RefID,
             stats: None,
             codec: Codecs::Brotli,
+            dictionary_id: None,
+            is_tokenized: false,
         }
     }
 }
@@ -238,18 +247,60 @@ fn flush_field_buffer<WS: Write + Seek>(
         inner.generate_block_info(),
         data,
         codec,
+        &file_meta
     );
 
     let mut completed_task = compressor.get_compr_block();
+    // let mut updated_task = compressor.handle_compression_result(completed_task, file_meta);
 
-    if let OrderingKey::Key(key) = completed_task.ordering_key {
-        write_data_and_update_meta(writer, file_meta, key, &mut completed_task);
-    }
+    // if let OrderingKey::Key(key) = completed_task.ordering_key {
+    //     write_data_and_update_meta(writer, file_meta, key, &mut completed_task);
+    // }
+
+    // Use updated_task.buf instead of completed_task.buf
+    // inner.buffer = completed_task.buf;
 
     // We need to reuse the same buffer for the next task, as it is always the same size so we can avoid re-allocating the same buffer for each processed block
-    inner.buffer = completed_task.buf;
+    // inner.buffer = completed_task.buf;
+
+    // Handle dictionary updates after compression
+    let mut updated_task = handle_dictionary_result(completed_task, file_meta);
+
+    if let OrderingKey::Key(key) = updated_task.ordering_key {
+        write_data_and_update_meta(writer, file_meta, key, &mut updated_task);
+    }
+
+    inner.buffer = updated_task.buf;
+    inner.reset_for_new_block();
 
     inner.reset_for_new_block();
+}
+
+fn handle_dictionary_result(mut task: CompressTask, file_meta: &mut FileMeta) -> CompressTask {
+    if let Some(dict_info) = task.dictionary_info.take() {
+        match dict_info.action {
+            DictionaryAction::CreateNew(dict_data) => {
+                let actual_dict_id = file_meta.add_dictionary(
+                    dict_data, 
+                    dict_info.tokenization_method, 
+                    task.block_info.numitems
+                );
+                
+                // Update block info with actual dictionary ID
+                task.block_info.dictionary_id = Some(actual_dict_id);
+                println!("Created new dictionary with ID: {}", actual_dict_id);
+            }
+            DictionaryAction::UseExisting(dict_id) => {
+                file_meta.increment_dictionary_usage(dict_id);
+                println!("Used existing dictionary {}", dict_id);
+            }
+            DictionaryAction::None => {
+                // No action needed
+            }
+        }
+    }
+    
+    task
 }
 
 fn write_data_and_update_meta<WS: Write + Seek>(
@@ -288,6 +339,8 @@ fn generate_meta<S: Seek>(
         block_size,
         uncompressed_size: block_info.uncompr_size as u64,
         stats: block_info.stats.take(),
+        dictionary_id: block_info.dictionary_id,
+        is_tokenized: block_info.is_tokenized,
     }
 }
 
@@ -358,6 +411,8 @@ impl Inner {
             field: self.field,
             stats: stat,
             codec: codec,
+            dictionary_id: None,
+            is_tokenized: false,
         }
     }
 }

--- a/gbam_tools/src/writer.rs
+++ b/gbam_tools/src/writer.rs
@@ -288,7 +288,6 @@ fn handle_dictionary_result(mut task: CompressTask, file_meta: &mut FileMeta) ->
                 
                 // Update block info with actual dictionary ID
                 task.block_info.dictionary_id = Some(actual_dict_id);
-                println!("Created new dictionary with ID: {}", actual_dict_id);
             }
             DictionaryAction::UseExisting(dict_id) => {
                 file_meta.increment_dictionary_usage(dict_id);


### PR DESCRIPTION
**Conversion example:**

```
String: "HWUSI-EAS566_0007:2:30:18804:9636#0|AGC" (39 bytes, variable)
   ↓
Token: {
    instrument_id: 0,      // Points to dictionary[0] = "HWUSI-EAS566_0007"
    run_id: 3234567890,    // Hash of instrument (legacy format)
    flowcell_id: 0,        // Legacy format
    lane: 2,               // Parsed from string
    tile: 30,              // Parsed from string  
    x_coord: 18804,        // Parsed from string
    y_coord: 9636,         // Parsed from string
    umi_id: Some(0),       // Points to dictionary[0] = "AGC"
    read_num: 1,           // Default
    flags: 0,              // Default
    index_id: Some(0),     // Points to dictionary[0] = "0"
} (22 bytes, fixed)
```

**Complete ReadName compression pipeline:**

```
Original Read Names (strings)
    ↓ Tokenization
Fixed Binary Records + Dictionary
    ↓ Post-Tokenization Compression
    ├─ Delta encoding on coordinates  
    ├─ RLE on repeated metadata
    ├─ Huffman on value distributions
    └─ Deflate on optimized streams
    ↓
Highly Compressed Binary Data
```